### PR TITLE
Fix Authorization Matrix property support on jobs in a folder

### DIFF
--- a/jenkins_jobs/modules/properties.py
+++ b/jenkins_jobs/modules/properties.py
@@ -1268,6 +1268,8 @@ class Properties(jenkins_jobs.modules.base.Base):
                 if "project-type" in data:
                     if data["project-type"] == "folder":
                         prop["authorization"]["_use_folder_perms"] = True
+                    elif data["project-type"] == "multibranch":
+                        prop["authorization"]["_use_folder_perms"] = True
                     else:
                         prop["authorization"]["_use_folder_perms"] = "folder" in data
                 else:

--- a/jenkins_jobs/modules/properties.py
+++ b/jenkins_jobs/modules/properties.py
@@ -521,6 +521,8 @@ def authorization(registry, xml_parent, data):
     # get the folder name if it exists
     in_a_folder = data.pop("_use_folder_perms", None) if data else None
 
+    is_a_folder = data['project-type'] == 'folder'
+
     credentials = "com.cloudbees.plugins.credentials.CredentialsProvider."
     ownership = "com.synopsys.arc.jenkins.plugins.ownership.OwnershipPlugin."
 
@@ -549,9 +551,13 @@ def authorization(registry, xml_parent, data):
 
     if data:
         if in_a_folder:
+            if is_a_folder:
+                element_name = "com.cloudbees.hudson.plugins.folder.properties.AuthorizationMatrixProperty"
+            else:
+                element_name = "hudson.security.AuthorizationMatrixProperty"
             matrix = XML.SubElement(
                 xml_parent,
-                "com.cloudbees.hudson.plugins.folder.properties.AuthorizationMatrixProperty",
+                element_name,
             )
             XML.SubElement(
                 matrix,

--- a/jenkins_jobs/modules/publishers.py
+++ b/jenkins_jobs/modules/publishers.py
@@ -4256,6 +4256,10 @@ def postbuildscript(registry, xml_parent, data):
                            the scripts. Valid options:
                            SUCCESS / UNSTABLE / FAILURE / NOT_BUILT / ABORTED
                            (default 'SUCCESS')
+                         * ** execute-on (`str`) - For matrix projects, scripts
+                           can be run after each axis is built (`axes`), after
+                           all axis of the matrix are built (`matrix`) or after
+                           each axis AND the matrix are built (`both`). (default `both`)
 
     :arg list groovy-script: Paths to Groovy scripts
 
@@ -4266,6 +4270,10 @@ def postbuildscript(registry, xml_parent, data):
                           the scripts. Valid options:
                           SUCCESS / UNSTABLE / FAILURE / NOT_BUILT / ABORTED
                           (default 'SUCCESS')
+                        * ** execute-on (`str`) - For matrix projects, scripts
+                          can be run after each axis is built (`axes`), after
+                          all axis of the matrix are built (`matrix`) or after
+                          each axis AND the matrix are built (`both`). (default `both`)
 
     :arg list groovy: Inline Groovy
 
@@ -4276,6 +4284,10 @@ def postbuildscript(registry, xml_parent, data):
                    the scripts. Valid options:
                    SUCCESS / UNSTABLE / FAILURE / NOT_BUILT / ABORTED
                    (default 'SUCCESS')
+                 * ** execute-on (`str`) - For matrix projects, scripts
+                   can be run after each axis is built (`axes`), after
+                   all axis of the matrix are built (`matrix`) or after
+                   each axis AND the matrix are built (`both`). (default `both`)
 
     :arg list builders: Execute any number of supported Jenkins builders.
 
@@ -4287,6 +4299,10 @@ def postbuildscript(registry, xml_parent, data):
                      the scripts. Valid options:
                      SUCCESS / UNSTABLE / FAILURE / NOT_BUILT / ABORTED
                      (default 'SUCCESS')
+                   * ** execute-on (`str`) - For matrix projects, scripts
+                     can be run after each axis is built (`axes`), after
+                     all axis of the matrix are built (`matrix`) or after
+                     each axis AND the matrix are built (`both`). (default `both`)
 
     :arg bool mark-unstable-if-failed: Build will be marked unstable
         if job will be successfully completed but publishing script will return
@@ -4300,7 +4316,6 @@ def postbuildscript(registry, xml_parent, data):
     :arg bool onfailure: Deprecated, replaced with script-only-if-failed
     :arg bool script-only-if-failed: Scripts and builders are run only if the
         build failed (default false)
-
     :arg str execute-on: For matrix projects, scripts can be run after each
         axis is built (`axes`), after all axis of the matrix are built
         (`matrix`) or after each axis AND the matrix are built (`both`).
@@ -4355,6 +4370,18 @@ def postbuildscript(registry, xml_parent, data):
 
     if version >= pkg_resources.parse_version("2.0"):
 
+        def add_execute_on(bs_data, result_xml):
+            valid_values = ("matrix", "axes", "both")
+            execute_on = bs_data.get("execute-on")
+            if not execute_on:
+                return
+            if execute_on not in valid_values:
+                raise JenkinsJobsException(
+                    "execute-on must be one of %s, got %s" % valid_values, execute_on
+                )
+            execute_on_xml = XML.SubElement(result_xml, "executeOn")
+            execute_on_xml.text = execute_on.upper()
+
         ################
         # Script Files #
         ################
@@ -4370,6 +4397,8 @@ def postbuildscript(registry, xml_parent, data):
             for result in gs_data.get("build-on", ["SUCCESS"]):
                 XML.SubElement(results_xml, "string").text = result
 
+            add_execute_on(gs_data, x)
+
             helpers.convert_mapping_to_xml(
                 x, gs_data, script_mapping, fail_required=True
             )
@@ -4381,6 +4410,8 @@ def postbuildscript(registry, xml_parent, data):
 
             for result in gs_data.get("build-on", ["SUCCESS"]):
                 XML.SubElement(results_xml, "string").text = result
+
+            add_execute_on(gs_data, x)
 
             helpers.convert_mapping_to_xml(
                 x, gs_data, script_mapping, fail_required=True
@@ -4401,6 +4432,8 @@ def postbuildscript(registry, xml_parent, data):
             for result in gs_data.get("build-on", ["SUCCESS"]):
                 XML.SubElement(results_xml, "string").text = result
 
+            add_execute_on(gs_data, x)
+
             helpers.convert_mapping_to_xml(
                 x, gs_data, groovy_mapping, fail_required=True
             )
@@ -4418,6 +4451,8 @@ def postbuildscript(registry, xml_parent, data):
 
             for result in bs_data.get("build-on", ["SUCCESS"]):
                 XML.SubElement(results_xml, "string").text = result
+
+            add_execute_on(bs_data, x)
 
             helpers.convert_mapping_to_xml(
                 x, bs_data, builder_mapping, fail_required=True

--- a/jenkins_jobs/modules/publishers.py
+++ b/jenkins_jobs/modules/publishers.py
@@ -2471,6 +2471,12 @@ def base_email_ext(registry, xml_parent, data, ttype):
         XML.SubElement(email, "sendToRecipientList").text = str(
             "recipients" in data["send-to"]
         ).lower()
+        if "upstream-committers" in data["send-to"]:
+            recipient_providers = XML.SubElement(email, "recipientProviders")
+            XML.SubElement(
+                recipient_providers,
+                "hudson.plugins.emailext.plugins.recipients.UpstreamComitterRecipientProvider",
+            ).text = ""
     else:
         XML.SubElement(email, "sendToRequester").text = "false"
         XML.SubElement(email, "sendToDevelopers").text = "false"
@@ -2554,6 +2560,7 @@ def email_ext(registry, xml_parent, data):
             * **requester** (disabled by default)
             * **culprits** (disabled by default)
             * **recipients** (enabled by default)
+            * **upstream-committers** (>=2.39) (disabled by default)
 
     Example:
 

--- a/jenkins_jobs/modules/triggers.py
+++ b/jenkins_jobs/modules/triggers.py
@@ -1410,6 +1410,8 @@ def gitlab(registry, xml_parent, data):
         (default true)
     :arg bool set-build-description: Set build description to build cause
         (eg. Merge request or Git Push) (default true)
+    :arg bool cancel-pending-builds-on-update: Cancel pending merge request
+        builds on update (default false)
     :arg bool add-note-merge-request: Add note with build status on
         merge requests (default true)
     :arg bool add-vote-merge-request: Vote added to note with build status
@@ -1521,6 +1523,7 @@ def gitlab(registry, xml_parent, data):
         ("ci-skip", "ciSkip", True),
         ("wip-skip", "skipWorkInProgressMergeRequest", True),
         ("set-build-description", "setBuildDescription", True),
+        ("cancel-pending-builds-on-update", "cancelPendingBuildsOnUpdate", False),
         ("add-note-merge-request", "addNoteOnMergeRequest", True),
         ("add-vote-merge-request", "addVoteOnMergeRequest", True),
         ("accept-merge-request-on-success", "acceptMergeRequestOnSuccess", False),

--- a/jenkins_jobs/modules/zuul.py
+++ b/jenkins_jobs/modules/zuul.py
@@ -17,7 +17,7 @@ The Zuul module adds jobs parameters to manually run a build as Zuul would
 have. It is entirely optional, Zuul 2.0+ pass the parameters over Gearman.
 
 .. _expected by Zuul: \
-https://opendev.org/zuul/zuul/src/tag/2.6.0/doc/source/launchers.rst#zuul-parameters
+https://opendev.org/zuul/zuul/src/tag/2.6.0/doc/source/launchers.rst#user-content-zuul-parameters
 """
 
 import itertools

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,7 +8,7 @@ python-subunit>=0.0.18 # Apache-2.0/BSD
 sphinx>=1.5.0,<1.7.0
 testscenarios>=0.4 # Apache-2.0/BSD
 testtools>=1.4.0 # MIT
-stestr>=2.0.0 # Apache-2.0/BSD
+stestr>=2.0.0,!=3.0.0 # Apache-2.0/BSD
 tox>=2.9.1 # MIT
 mock>=2.0 # BSD
 sphinxcontrib-programoutput

--- a/tests/publishers/fixtures/email-ext001.xml
+++ b/tests/publishers/fixtures/email-ext001.xml
@@ -13,6 +13,9 @@
             <sendToRequester>true</sendToRequester>
             <includeCulprits>true</includeCulprits>
             <sendToRecipientList>true</sendToRecipientList>
+            <recipientProviders>
+              <hudson.plugins.emailext.plugins.recipients.UpstreamComitterRecipientProvider/>
+            </recipientProviders>
           </email>
         </hudson.plugins.emailext.plugins.trigger.AlwaysTrigger>
         <hudson.plugins.emailext.plugins.trigger.UnstableTrigger>
@@ -24,6 +27,9 @@
             <sendToRequester>true</sendToRequester>
             <includeCulprits>true</includeCulprits>
             <sendToRecipientList>true</sendToRecipientList>
+            <recipientProviders>
+              <hudson.plugins.emailext.plugins.recipients.UpstreamComitterRecipientProvider/>
+            </recipientProviders>
           </email>
         </hudson.plugins.emailext.plugins.trigger.UnstableTrigger>
         <hudson.plugins.emailext.plugins.trigger.FirstFailureTrigger>
@@ -35,6 +41,9 @@
             <sendToRequester>true</sendToRequester>
             <includeCulprits>true</includeCulprits>
             <sendToRecipientList>true</sendToRecipientList>
+            <recipientProviders>
+              <hudson.plugins.emailext.plugins.recipients.UpstreamComitterRecipientProvider/>
+            </recipientProviders>
           </email>
         </hudson.plugins.emailext.plugins.trigger.FirstFailureTrigger>
         <hudson.plugins.emailext.plugins.trigger.FirstUnstableTrigger>
@@ -46,6 +55,9 @@
             <sendToRequester>true</sendToRequester>
             <includeCulprits>true</includeCulprits>
             <sendToRecipientList>true</sendToRecipientList>
+            <recipientProviders>
+              <hudson.plugins.emailext.plugins.recipients.UpstreamComitterRecipientProvider/>
+            </recipientProviders>
           </email>
         </hudson.plugins.emailext.plugins.trigger.FirstUnstableTrigger>
         <hudson.plugins.emailext.plugins.trigger.NotBuiltTrigger>
@@ -57,6 +69,9 @@
             <sendToRequester>true</sendToRequester>
             <includeCulprits>true</includeCulprits>
             <sendToRecipientList>true</sendToRecipientList>
+            <recipientProviders>
+              <hudson.plugins.emailext.plugins.recipients.UpstreamComitterRecipientProvider/>
+            </recipientProviders>
           </email>
         </hudson.plugins.emailext.plugins.trigger.NotBuiltTrigger>
         <hudson.plugins.emailext.plugins.trigger.AbortedTrigger>
@@ -68,6 +83,9 @@
             <sendToRequester>true</sendToRequester>
             <includeCulprits>true</includeCulprits>
             <sendToRecipientList>true</sendToRecipientList>
+            <recipientProviders>
+              <hudson.plugins.emailext.plugins.recipients.UpstreamComitterRecipientProvider/>
+            </recipientProviders>
           </email>
         </hudson.plugins.emailext.plugins.trigger.AbortedTrigger>
         <hudson.plugins.emailext.plugins.trigger.RegressionTrigger>
@@ -79,6 +97,9 @@
             <sendToRequester>true</sendToRequester>
             <includeCulprits>true</includeCulprits>
             <sendToRecipientList>true</sendToRecipientList>
+            <recipientProviders>
+              <hudson.plugins.emailext.plugins.recipients.UpstreamComitterRecipientProvider/>
+            </recipientProviders>
           </email>
         </hudson.plugins.emailext.plugins.trigger.RegressionTrigger>
         <hudson.plugins.emailext.plugins.trigger.FailureTrigger>
@@ -90,6 +111,9 @@
             <sendToRequester>true</sendToRequester>
             <includeCulprits>true</includeCulprits>
             <sendToRecipientList>true</sendToRecipientList>
+            <recipientProviders>
+              <hudson.plugins.emailext.plugins.recipients.UpstreamComitterRecipientProvider/>
+            </recipientProviders>
           </email>
         </hudson.plugins.emailext.plugins.trigger.FailureTrigger>
         <hudson.plugins.emailext.plugins.trigger.SecondFailureTrigger>
@@ -101,6 +125,9 @@
             <sendToRequester>true</sendToRequester>
             <includeCulprits>true</includeCulprits>
             <sendToRecipientList>true</sendToRecipientList>
+            <recipientProviders>
+              <hudson.plugins.emailext.plugins.recipients.UpstreamComitterRecipientProvider/>
+            </recipientProviders>
           </email>
         </hudson.plugins.emailext.plugins.trigger.SecondFailureTrigger>
         <hudson.plugins.emailext.plugins.trigger.ImprovementTrigger>
@@ -112,6 +139,9 @@
             <sendToRequester>true</sendToRequester>
             <includeCulprits>true</includeCulprits>
             <sendToRecipientList>true</sendToRecipientList>
+            <recipientProviders>
+              <hudson.plugins.emailext.plugins.recipients.UpstreamComitterRecipientProvider/>
+            </recipientProviders>
           </email>
         </hudson.plugins.emailext.plugins.trigger.ImprovementTrigger>
         <hudson.plugins.emailext.plugins.trigger.StillFailingTrigger>
@@ -123,6 +153,9 @@
             <sendToRequester>true</sendToRequester>
             <includeCulprits>true</includeCulprits>
             <sendToRecipientList>true</sendToRecipientList>
+            <recipientProviders>
+              <hudson.plugins.emailext.plugins.recipients.UpstreamComitterRecipientProvider/>
+            </recipientProviders>
           </email>
         </hudson.plugins.emailext.plugins.trigger.StillFailingTrigger>
         <hudson.plugins.emailext.plugins.trigger.SuccessTrigger>
@@ -134,6 +167,9 @@
             <sendToRequester>true</sendToRequester>
             <includeCulprits>true</includeCulprits>
             <sendToRecipientList>true</sendToRecipientList>
+            <recipientProviders>
+              <hudson.plugins.emailext.plugins.recipients.UpstreamComitterRecipientProvider/>
+            </recipientProviders>
           </email>
         </hudson.plugins.emailext.plugins.trigger.SuccessTrigger>
         <hudson.plugins.emailext.plugins.trigger.FixedTrigger>
@@ -145,6 +181,9 @@
             <sendToRequester>true</sendToRequester>
             <includeCulprits>true</includeCulprits>
             <sendToRecipientList>true</sendToRecipientList>
+            <recipientProviders>
+              <hudson.plugins.emailext.plugins.recipients.UpstreamComitterRecipientProvider/>
+            </recipientProviders>
           </email>
         </hudson.plugins.emailext.plugins.trigger.FixedTrigger>
         <hudson.plugins.emailext.plugins.trigger.FixedUnhealthyTrigger>
@@ -156,6 +195,9 @@
             <sendToRequester>true</sendToRequester>
             <includeCulprits>true</includeCulprits>
             <sendToRecipientList>true</sendToRecipientList>
+            <recipientProviders>
+              <hudson.plugins.emailext.plugins.recipients.UpstreamComitterRecipientProvider/>
+            </recipientProviders>
           </email>
         </hudson.plugins.emailext.plugins.trigger.FixedUnhealthyTrigger>
         <hudson.plugins.emailext.plugins.trigger.StillUnstableTrigger>
@@ -167,6 +209,9 @@
             <sendToRequester>true</sendToRequester>
             <includeCulprits>true</includeCulprits>
             <sendToRecipientList>true</sendToRecipientList>
+            <recipientProviders>
+              <hudson.plugins.emailext.plugins.recipients.UpstreamComitterRecipientProvider/>
+            </recipientProviders>
           </email>
         </hudson.plugins.emailext.plugins.trigger.StillUnstableTrigger>
         <hudson.plugins.emailext.plugins.trigger.PreBuildTrigger>
@@ -178,6 +223,9 @@
             <sendToRequester>true</sendToRequester>
             <includeCulprits>true</includeCulprits>
             <sendToRecipientList>true</sendToRecipientList>
+            <recipientProviders>
+              <hudson.plugins.emailext.plugins.recipients.UpstreamComitterRecipientProvider/>
+            </recipientProviders>
           </email>
         </hudson.plugins.emailext.plugins.trigger.PreBuildTrigger>
       </configuredTriggers>

--- a/tests/publishers/fixtures/email-ext001.yaml
+++ b/tests/publishers/fixtures/email-ext001.yaml
@@ -33,3 +33,4 @@ publishers:
         - requester
         - culprits
         - recipients
+        - upstream-committers

--- a/tests/publishers/fixtures/postbuildscript-full.xml
+++ b/tests/publishers/fixtures/postbuildscript-full.xml
@@ -20,6 +20,7 @@
               <string>ABORTED</string>
               <string>FAILURE</string>
             </results>
+            <executeOn>MATRIX</executeOn>
             <role>SLAVE</role>
             <filePath>/fakepath/generic-two</filePath>
             <scriptType>GENERIC</scriptType>
@@ -29,6 +30,7 @@
               <string>SUCCESS</string>
               <string>UNSTABLE</string>
             </results>
+            <executeOn>AXES</executeOn>
             <role>MASTER</role>
             <filePath>/fakepath/groovy</filePath>
             <scriptType>GROOVY</scriptType>
@@ -50,6 +52,7 @@
               <string>SUCCESS</string>
               <string>UNSTABLE</string>
             </results>
+            <executeOn>MATRIX</executeOn>
             <role>MASTER</role>
             <content>println &quot;Hello world!&quot;</content>
           </org.jenkinsci.plugins.postbuildscript.model.Script>
@@ -71,6 +74,7 @@ println &quot;Multi-line script&quot;
               <string>SUCCESS</string>
               <string>UNSTABLE</string>
             </results>
+            <executeOn>AXES</executeOn>
             <role>MASTER</role>
             <buildSteps>
               <hudson.tasks.Shell>
@@ -84,6 +88,7 @@ println &quot;Multi-line script&quot;
               <string>ABORTED</string>
               <string>FAILURE</string>
             </results>
+            <executeOn>BOTH</executeOn>
             <role>SLAVE</role>
             <buildSteps>
               <hudson.tasks.Shell>

--- a/tests/publishers/fixtures/postbuildscript-full.yaml
+++ b/tests/publishers/fixtures/postbuildscript-full.yaml
@@ -13,12 +13,14 @@ publishers:
                   - NOT_BUILT
                   - ABORTED
                   - FAILURE
+              execute-on: matrix
         groovy-script:
             - file-path: '/fakepath/groovy'
               role: MASTER
               build-on:
                   - SUCCESS
                   - UNSTABLE
+              execute-on: axes
             - file-path: '/fakepath/groovy-too'
               role: SLAVE
               build-on:
@@ -30,6 +32,7 @@ publishers:
               build-on:
                   - SUCCESS
                   - UNSTABLE
+              execute-on: matrix
               content: 'println "Hello world!"'
             - role: SLAVE
               build-on:
@@ -45,6 +48,7 @@ publishers:
               build-on:
                   - SUCCESS
                   - UNSTABLE
+              execute-on: axes
               build-steps:
                   - shell: 'echo "Hello world!"'
             - role: SLAVE
@@ -52,6 +56,7 @@ publishers:
                   - NOT_BUILT
                   - ABORTED
                   - FAILURE
+              execute-on: both
               build-steps:
                   - shell: 'echo "Hello world!"'
                   - shell: 'echo "Goodbye world!"'

--- a/tests/triggers/fixtures/gitlab001.xml
+++ b/tests/triggers/fixtures/gitlab001.xml
@@ -14,6 +14,7 @@
       <ciSkip>true</ciSkip>
       <skipWorkInProgressMergeRequest>true</skipWorkInProgressMergeRequest>
       <setBuildDescription>true</setBuildDescription>
+      <cancelPendingBuildsOnUpdate>false</cancelPendingBuildsOnUpdate>
       <addNoteOnMergeRequest>true</addNoteOnMergeRequest>
       <addVoteOnMergeRequest>true</addVoteOnMergeRequest>
       <acceptMergeRequestOnSuccess>false</acceptMergeRequestOnSuccess>

--- a/tests/triggers/fixtures/gitlab002.xml
+++ b/tests/triggers/fixtures/gitlab002.xml
@@ -14,6 +14,7 @@
       <ciSkip>true</ciSkip>
       <skipWorkInProgressMergeRequest>true</skipWorkInProgressMergeRequest>
       <setBuildDescription>true</setBuildDescription>
+      <cancelPendingBuildsOnUpdate>false</cancelPendingBuildsOnUpdate>
       <addNoteOnMergeRequest>true</addNoteOnMergeRequest>
       <addVoteOnMergeRequest>true</addVoteOnMergeRequest>
       <acceptMergeRequestOnSuccess>false</acceptMergeRequestOnSuccess>

--- a/tests/triggers/fixtures/gitlab003.xml
+++ b/tests/triggers/fixtures/gitlab003.xml
@@ -14,6 +14,7 @@
       <ciSkip>true</ciSkip>
       <skipWorkInProgressMergeRequest>true</skipWorkInProgressMergeRequest>
       <setBuildDescription>true</setBuildDescription>
+      <cancelPendingBuildsOnUpdate>false</cancelPendingBuildsOnUpdate>
       <addNoteOnMergeRequest>true</addNoteOnMergeRequest>
       <addVoteOnMergeRequest>true</addVoteOnMergeRequest>
       <acceptMergeRequestOnSuccess>false</acceptMergeRequestOnSuccess>

--- a/tests/triggers/fixtures/gitlab004.xml
+++ b/tests/triggers/fixtures/gitlab004.xml
@@ -14,6 +14,7 @@
       <ciSkip>false</ciSkip>
       <skipWorkInProgressMergeRequest>true</skipWorkInProgressMergeRequest>
       <setBuildDescription>false</setBuildDescription>
+      <cancelPendingBuildsOnUpdate>false</cancelPendingBuildsOnUpdate>
       <addNoteOnMergeRequest>false</addNoteOnMergeRequest>
       <addVoteOnMergeRequest>false</addVoteOnMergeRequest>
       <acceptMergeRequestOnSuccess>false</acceptMergeRequestOnSuccess>

--- a/tests/triggers/fixtures/gitlab005.xml
+++ b/tests/triggers/fixtures/gitlab005.xml
@@ -14,6 +14,7 @@
       <ciSkip>true</ciSkip>
       <skipWorkInProgressMergeRequest>true</skipWorkInProgressMergeRequest>
       <setBuildDescription>true</setBuildDescription>
+      <cancelPendingBuildsOnUpdate>false</cancelPendingBuildsOnUpdate>
       <addNoteOnMergeRequest>true</addNoteOnMergeRequest>
       <addVoteOnMergeRequest>true</addVoteOnMergeRequest>
       <acceptMergeRequestOnSuccess>false</acceptMergeRequestOnSuccess>

--- a/tests/triggers/fixtures/gitlab006.xml
+++ b/tests/triggers/fixtures/gitlab006.xml
@@ -14,6 +14,7 @@
       <ciSkip>false</ciSkip>
       <skipWorkInProgressMergeRequest>false</skipWorkInProgressMergeRequest>
       <setBuildDescription>false</setBuildDescription>
+      <cancelPendingBuildsOnUpdate>false</cancelPendingBuildsOnUpdate>
       <addNoteOnMergeRequest>false</addNoteOnMergeRequest>
       <addVoteOnMergeRequest>false</addVoteOnMergeRequest>
       <acceptMergeRequestOnSuccess>true</acceptMergeRequestOnSuccess>

--- a/tests/triggers/fixtures/gitlab007.xml
+++ b/tests/triggers/fixtures/gitlab007.xml
@@ -14,6 +14,7 @@
       <ciSkip>true</ciSkip>
       <skipWorkInProgressMergeRequest>true</skipWorkInProgressMergeRequest>
       <setBuildDescription>true</setBuildDescription>
+      <cancelPendingBuildsOnUpdate>false</cancelPendingBuildsOnUpdate>
       <addNoteOnMergeRequest>true</addNoteOnMergeRequest>
       <addVoteOnMergeRequest>true</addVoteOnMergeRequest>
       <acceptMergeRequestOnSuccess>false</acceptMergeRequestOnSuccess>

--- a/tests/triggers/fixtures/gitlab007.yaml
+++ b/tests/triggers/fixtures/gitlab007.yaml
@@ -6,6 +6,7 @@ triggers:
       trigger-closed-merge-request: true
       ci-skip: true
       set-build-description: true
+      cancel-pending-builds-on-update: false
       add-note-merge-request: true
       add-vote-merge-request: true
       add-ci-message: true

--- a/tests/triggers/fixtures/gitlab008.xml
+++ b/tests/triggers/fixtures/gitlab008.xml
@@ -14,6 +14,7 @@
       <ciSkip>false</ciSkip>
       <skipWorkInProgressMergeRequest>true</skipWorkInProgressMergeRequest>
       <setBuildDescription>false</setBuildDescription>
+      <cancelPendingBuildsOnUpdate>true</cancelPendingBuildsOnUpdate>
       <addNoteOnMergeRequest>false</addNoteOnMergeRequest>
       <addVoteOnMergeRequest>false</addVoteOnMergeRequest>
       <acceptMergeRequestOnSuccess>false</acceptMergeRequestOnSuccess>

--- a/tests/triggers/fixtures/gitlab008.yaml
+++ b/tests/triggers/fixtures/gitlab008.yaml
@@ -5,6 +5,7 @@ triggers:
       trigger-open-merge-request-push: both
       ci-skip: false
       set-build-description: false
+      cancel-pending-builds-on-update: true
       add-note-merge-request: false
       add-vote-merge-request: false
       add-ci-message: true


### PR DESCRIPTION
Without the fix:
    
> 2020-05-11 10:56:12.238+0000 [id=29522]   WARNING o.e.j.s.h.ContextHandler$Context#log: Error while serving http://localhost/job/someFolder/createItem
> java.lang.ClassCastException: com.cloudbees.hudson.plugins.folder.properties.AuthorizationMatrixProperty cannot be cast to hudson.model.JobProperty
    
It turns out com.cloudbees.hudson.plugins.folder.properties.AuthorizationMatrixProperty should only be applied to Folders, not Jobs.