### PR TITLE
Fix Authorization Matrix property support on jobs in a folder

### DIFF
--- a/jenkins_jobs/modules/properties.py
+++ b/jenkins_jobs/modules/properties.py
@@ -521,6 +521,8 @@ def authorization(registry, xml_parent, data):
     # get the folder name if it exists
     in_a_folder = data.pop("_use_folder_perms", None) if data else None
 
+    is_a_folder = data['project-type'] == 'folder'
+
     credentials = "com.cloudbees.plugins.credentials.CredentialsProvider."
     ownership = "com.synopsys.arc.jenkins.plugins.ownership.OwnershipPlugin."
 
@@ -549,9 +551,13 @@ def authorization(registry, xml_parent, data):
 
     if data:
         if in_a_folder:
+            if is_a_folder:
+                element_name = "com.cloudbees.hudson.plugins.folder.properties.AuthorizationMatrixProperty"
+            else:
+                element_name = "hudson.security.AuthorizationMatrixProperty"
             matrix = XML.SubElement(
                 xml_parent,
-                "com.cloudbees.hudson.plugins.folder.properties.AuthorizationMatrixProperty",
+                element_name,
             )
             XML.SubElement(
                 matrix,


### PR DESCRIPTION
Without the fix:

> 2020-05-11 10:56:12.238+0000 [id=29522]	WARNING
> o.e.j.s.h.ContextHandler$Context#log: Error while serving http://localhost/job/someFolder/createItem
> java.lang.ClassCastException: com.cloudbees.hudson.plugins.folder.properties.AuthorizationMatrixProperty cannot be cast to hudson.model.JobProperty

It turns out com.cloudbees.hudson.plugins.folder.properties.AuthorizationMatrixProperty
should only be applied to Folders, not Jobs.