### PR TITLE
[ONEM-15965] Pipelines: stop producing unsupported and deprecated XML tags

### DIFF
--- a/jenkins_jobs/modules/publishers.py
+++ b/jenkins_jobs/modules/publishers.py
@@ -39,6 +39,8 @@ import jenkins_jobs.modules.base
 from jenkins_jobs.modules import hudson_model
 import jenkins_jobs.modules.helpers as helpers
 
+logger = logging.getLogger(__name__)
+
 
 def influx_db(registry, xml_parent, data):
     """yaml: influx-db
@@ -8187,6 +8189,10 @@ class Publishers(jenkins_jobs.modules.base.Base):
     component_list_type = "publishers"
 
     def gen_xml(self, xml_parent, data):
+        if data.get("project-type", "freestyle") == "pipeline":
+            logger.debug("Publishers skipped for Pipeline job")
+            return
+
         publishers = XML.SubElement(xml_parent, "publishers")
 
         for action in data.get("publishers", []):

--- a/jenkins_jobs/modules/scm.py
+++ b/jenkins_jobs/modules/scm.py
@@ -1679,8 +1679,14 @@ class SCM(jenkins_jobs.modules.base.Base):
     def gen_xml(self, xml_parent, data):
 
         # multibranch-pipeline scm implementation is incompatible with SCM
-        if data.get("project-type") in ["multibranch", "multibranch-defaults"]:
-            logging.debug("SCM Module skipped for multibranch project-type.")
+        if data.get("project-type") in [
+            "multibranch",
+            "multibranch-defaults",
+            "pipeline",
+        ]:
+            logging.debug(
+                "SCM Module skipped for %s project-type." % data.get("project-type")
+            )
             return
 
         scms_parent = XML.Element("scms")

--- a/jenkins_jobs/modules/triggers.py
+++ b/jenkins_jobs/modules/triggers.py
@@ -2454,6 +2454,17 @@ class Triggers(jenkins_jobs.modules.base.Base):
         if not triggers:
             return
 
-        trig_e = XML.SubElement(xml_parent, "triggers", {"class": "vector"})
+        if data.get("project-type", "freestyle") != "pipeline":
+            trig_e = XML.SubElement(xml_parent, "triggers", {"class": "vector"})
+        else:
+            properties = xml_parent.find("properties")
+            if properties is None:
+                properties = XML.SubElement(xml_parent, "properties")
+            pipeline_trig_prop = XML.SubElement(
+                properties,
+                "org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty",
+            )
+            trig_e = XML.SubElement(pipeline_trig_prop, "triggers")
+
         for trigger in triggers:
             self.registry.dispatch("trigger", trig_e, trigger)

--- a/jenkins_jobs/modules/wrappers.py
+++ b/jenkins_jobs/modules/wrappers.py
@@ -2962,6 +2962,10 @@ class Wrappers(jenkins_jobs.modules.base.Base):
     component_list_type = "wrappers"
 
     def gen_xml(self, xml_parent, data):
+        if data.get("project-type", "freestyle") == "pipeline":
+            logger.debug("Build wrappers skipped for Pipeline job")
+            return
+
         wrappers = XML.SubElement(xml_parent, "buildWrappers")
 
         for wrap in data.get("wrappers", []):

--- a/tests/yamlparser/fixtures/project_pipeline_concurrent.xml
+++ b/tests/yamlparser/fixtures/project_pipeline_concurrent.xml
@@ -2,19 +2,11 @@
 <flow-definition plugin="workflow-job">
   <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps">
     <script>build job: &quot;job1&quot;
-parallel [
-  2a: build job: &quot;job2a&quot;,
-  2b: node &quot;dummynode&quot; {
-    sh &quot;echo I'm alive!&quot;
-  }
-]
 </script>
     <sandbox>false</sandbox>
   </definition>
   <actions/>
   <description>&lt;!-- Managed by Jenkins Job Builder --&gt;</description>
   <keepDependencies>false</keepDependencies>
-  <properties>
-    <org.jenkinsci.plugins.workflow.job.properties.DisableConcurrentBuildsJobProperty/>
-  </properties>
+  <properties/>
 </flow-definition>

--- a/tests/yamlparser/fixtures/project_pipeline_concurrent.yaml
+++ b/tests/yamlparser/fixtures/project_pipeline_concurrent.yaml
@@ -1,0 +1,6 @@
+- job:
+    name: test_job
+    project-type: pipeline
+    dsl: |
+      build job: "job1"
+    concurrent: true

--- a/tests/yamlparser/fixtures/project_pipeline_template002.xml
+++ b/tests/yamlparser/fixtures/project_pipeline_template002.xml
@@ -14,12 +14,7 @@ parallel [
   <actions/>
   <description>&lt;!-- Managed by Jenkins Job Builder --&gt;</description>
   <keepDependencies>false</keepDependencies>
-  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
-  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
-  <concurrentBuild>false</concurrentBuild>
-  <canRoam>true</canRoam>
-  <properties/>
-  <scm class="hudson.scm.NullSCM"/>
-  <publishers/>
-  <buildWrappers/>
+  <properties>
+    <org.jenkinsci.plugins.workflow.job.properties.DisableConcurrentBuildsJobProperty/>
+  </properties>
 </flow-definition>

--- a/tests/yamlparser/fixtures/project_pipeline_template003.xml
+++ b/tests/yamlparser/fixtures/project_pipeline_template003.xml
@@ -14,12 +14,7 @@ parallel [
   <actions/>
   <description>&lt;!-- Managed by Jenkins Job Builder --&gt;</description>
   <keepDependencies>false</keepDependencies>
-  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
-  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
-  <concurrentBuild>false</concurrentBuild>
-  <canRoam>true</canRoam>
-  <properties/>
-  <scm class="hudson.scm.NullSCM"/>
-  <publishers/>
-  <buildWrappers/>
+  <properties>
+    <org.jenkinsci.plugins.workflow.job.properties.DisableConcurrentBuildsJobProperty/>
+  </properties>
 </flow-definition>

--- a/tests/yamlparser/fixtures/project_pipeline_template004.xml
+++ b/tests/yamlparser/fixtures/project_pipeline_template004.xml
@@ -16,12 +16,7 @@
   <actions/>
   <description>&lt;!-- Managed by Jenkins Job Builder --&gt;</description>
   <keepDependencies>false</keepDependencies>
-  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
-  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
-  <concurrentBuild>false</concurrentBuild>
-  <canRoam>true</canRoam>
-  <properties/>
-  <scm class="hudson.scm.NullSCM"/>
-  <publishers/>
-  <buildWrappers/>
+  <properties>
+    <org.jenkinsci.plugins.workflow.job.properties.DisableConcurrentBuildsJobProperty/>
+  </properties>
 </flow-definition>

--- a/tests/yamlparser/fixtures/project_pipeline_template005.xml
+++ b/tests/yamlparser/fixtures/project_pipeline_template005.xml
@@ -13,22 +13,11 @@
     <scriptPath>Jenkinsfile</scriptPath>
   </definition>
   <actions/>
-  <description>&lt;!-- Managed by Jenkins Job Builder --&gt;</description>
+  <description>maintainer: qa@example.org&lt;!-- Managed by Jenkins Job Builder --&gt;</description>
   <keepDependencies>false</keepDependencies>
-  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
-  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
-  <concurrentBuild>false</concurrentBuild>
-  <canRoam>true</canRoam>
-  <properties/>
-  <scm class="hudson.scm.NullSCM"/>
-  <publishers>
-    <hudson.tasks.Mailer plugin="mailer">
-      <recipients>qa@example.org</recipients>
-      <dontNotifyEveryUnstableBuild>false</dontNotifyEveryUnstableBuild>
-      <sendToIndividuals>false</sendToIndividuals>
-    </hudson.tasks.Mailer>
-  </publishers>
-  <buildWrappers/>
+  <properties>
+    <org.jenkinsci.plugins.workflow.job.properties.DisableConcurrentBuildsJobProperty/>
+  </properties>
 </flow-definition>
 <BLANKLINE>
 <?xml version="1.0" encoding="utf-8"?>
@@ -46,20 +35,9 @@
     <scriptPath>Jenkinsfile</scriptPath>
   </definition>
   <actions/>
-  <description>&lt;!-- Managed by Jenkins Job Builder --&gt;</description>
+  <description>maintainer: dev@example.org&lt;!-- Managed by Jenkins Job Builder --&gt;</description>
   <keepDependencies>false</keepDependencies>
-  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
-  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
-  <concurrentBuild>false</concurrentBuild>
-  <canRoam>true</canRoam>
-  <properties/>
-  <scm class="hudson.scm.NullSCM"/>
-  <publishers>
-    <hudson.tasks.Mailer plugin="mailer">
-      <recipients>dev@example.org</recipients>
-      <dontNotifyEveryUnstableBuild>false</dontNotifyEveryUnstableBuild>
-      <sendToIndividuals>false</sendToIndividuals>
-    </hudson.tasks.Mailer>
-  </publishers>
-  <buildWrappers/>
+  <properties>
+    <org.jenkinsci.plugins.workflow.job.properties.DisableConcurrentBuildsJobProperty/>
+  </properties>
 </flow-definition>

--- a/tests/yamlparser/fixtures/project_pipeline_template005.yaml
+++ b/tests/yamlparser/fixtures/project_pipeline_template005.yaml
@@ -12,9 +12,7 @@
       scm:
         - project-scm
     sandbox: true
-    publishers:
-    - email:
-        recipients: '{mail-to}'
+    description: 'maintainer: {maintainer}'
 
 - job-template:
     name: '{name}-perf-tests'
@@ -23,17 +21,15 @@
       scm:
         - project-scm
     sandbox: false
-    publishers:
-    - email:
-        recipients: '{mail-to}'
+    description: 'maintainer: {maintainer}'
 
 - job-group:
     name: '{name}-tests'
     jobs:
       - '{name}-unit-tests':
-          mail-to: dev@example.org
+          maintainer: dev@example.org
       - '{name}-perf-tests':
-          mail-to: qa@example.org
+          maintainer: qa@example.org
 
 - project:
     name: project-name

--- a/tests/yamlparser/fixtures/project_pipeline_template006.xml
+++ b/tests/yamlparser/fixtures/project_pipeline_template006.xml
@@ -10,12 +10,7 @@
   <actions/>
   <description>&lt;!-- Managed by Jenkins Job Builder --&gt;</description>
   <keepDependencies>false</keepDependencies>
-  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
-  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
-  <concurrentBuild>false</concurrentBuild>
-  <canRoam>true</canRoam>
-  <properties/>
-  <scm class="hudson.scm.NullSCM"/>
-  <publishers/>
-  <buildWrappers/>
+  <properties>
+    <org.jenkinsci.plugins.workflow.job.properties.DisableConcurrentBuildsJobProperty/>
+  </properties>
 </flow-definition>

--- a/tests/yamlparser/fixtures/project_pipeline_triggers.xml
+++ b/tests/yamlparser/fixtures/project_pipeline_triggers.xml
@@ -2,12 +2,6 @@
 <flow-definition plugin="workflow-job">
   <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps">
     <script>build job: &quot;job1&quot;
-parallel [
-  2a: build job: &quot;job2a&quot;,
-  2b: node &quot;dummynode&quot; {
-    sh &quot;echo I'm alive!&quot;
-  }
-]
 </script>
     <sandbox>false</sandbox>
   </definition>
@@ -16,5 +10,12 @@ parallel [
   <keepDependencies>false</keepDependencies>
   <properties>
     <org.jenkinsci.plugins.workflow.job.properties.DisableConcurrentBuildsJobProperty/>
+    <org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
+      <triggers>
+        <hudson.triggers.TimerTrigger>
+          <spec>@daily</spec>
+        </hudson.triggers.TimerTrigger>
+      </triggers>
+    </org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
   </properties>
 </flow-definition>

--- a/tests/yamlparser/fixtures/project_pipeline_triggers.yaml
+++ b/tests/yamlparser/fixtures/project_pipeline_triggers.yaml
@@ -1,0 +1,7 @@
+- job:
+    name: test_job
+    project-type: pipeline
+    dsl: |
+      build job: "job1"
+    triggers:
+    - timed: '@daily'


### PR DESCRIPTION
The changes include:
- `<concurrentBuild>` should now be represented as
  `<org.jenkinsci.plugins.workflow.job.properties.DisableConcurrentBuildsJobProperty/>`
  property
- `<triggers>` should now be localed inside
 `<org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>`
  property, in `<properties>` section
- unsupported XML elements got removed:
  - `<blockBuildWhenDownstreamBuilding>`
  - `<blockBuildWhenUpstreamBuilding>`
  - `<assignedNode>`
  - `<canRoam>`
  - `<customWorkspace>`
- got rid of publishers from `project_pipeline_template005.{xml,yaml}` as
  these are not supported in Pipeline jobs

The above changes align the produced XMLs with the ones from Jenkins 2.190.1
and Pipeline plugin v2.6.
