### PR TITLE
[ONEM-16011] Gerrit Trigger: update support to the latest plugin version

### DIFF
--- a/tests/jsonparser/fixtures/complete001.xml
+++ b/tests/jsonparser/fixtures/complete001.xml
@@ -68,14 +68,16 @@
       <silentMode>false</silentMode>
       <silentStartMode>false</silentStartMode>
       <escapeQuotes>true</escapeQuotes>
-      <noNameAndEmailParameters>false</noNameAndEmailParameters>
-      <readableMessage>false</readableMessage>
       <dependencyJobsNames/>
+      <commitMessageParameterMode>BASE64</commitMessageParameterMode>
+      <nameAndEmailParameterMode>PLAIN</nameAndEmailParameterMode>
+      <changeSubjectParameterMode>PLAIN</changeSubjectParameterMode>
+      <commentTextParameterMode>BASE64</commentTextParameterMode>
       <notificationLevel/>
-      <dynamicTriggerConfiguration>False</dynamicTriggerConfiguration>
+      <dynamicTriggerConfiguration>false</dynamicTriggerConfiguration>
       <triggerConfigURL/>
+      <dynamicGerritProjects class="empty-list"/>
       <triggerInformationAction/>
-      <allowTriggeringUnreviewedPatches>false</allowTriggeringUnreviewedPatches>
       <triggerOnEvents>
         <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginPatchsetCreatedEvent/>
       </triggerOnEvents>

--- a/tests/triggers/fixtures/gerrit001.xml
+++ b/tests/triggers/fixtures/gerrit001.xml
@@ -31,14 +31,15 @@
       <silentMode>false</silentMode>
       <silentStartMode>false</silentStartMode>
       <escapeQuotes>false</escapeQuotes>
-      <noNameAndEmailParameters>false</noNameAndEmailParameters>
-      <readableMessage>false</readableMessage>
       <dependencyJobsNames/>
+      <commitMessageParameterMode>BASE64</commitMessageParameterMode>
+      <nameAndEmailParameterMode>PLAIN</nameAndEmailParameterMode>
+      <changeSubjectParameterMode>PLAIN</changeSubjectParameterMode>
+      <commentTextParameterMode>BASE64</commentTextParameterMode>
       <notificationLevel/>
-      <dynamicTriggerConfiguration>True</dynamicTriggerConfiguration>
+      <dynamicTriggerConfiguration>true</dynamicTriggerConfiguration>
       <triggerConfigURL>http://myhost/mytrigger</triggerConfigURL>
       <triggerInformationAction/>
-      <allowTriggeringUnreviewedPatches>false</allowTriggeringUnreviewedPatches>
       <triggerOnEvents>
         <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginCommentAddedEvent>
           <verdictCategory>APRV</verdictCategory>

--- a/tests/triggers/fixtures/gerrit002.xml
+++ b/tests/triggers/fixtures/gerrit002.xml
@@ -35,14 +35,15 @@
       <silentMode>false</silentMode>
       <silentStartMode>false</silentStartMode>
       <escapeQuotes>false</escapeQuotes>
-      <noNameAndEmailParameters>false</noNameAndEmailParameters>
-      <readableMessage>false</readableMessage>
       <dependencyJobsNames/>
+      <commitMessageParameterMode>BASE64</commitMessageParameterMode>
+      <nameAndEmailParameterMode>PLAIN</nameAndEmailParameterMode>
+      <changeSubjectParameterMode>PLAIN</changeSubjectParameterMode>
+      <commentTextParameterMode>BASE64</commentTextParameterMode>
       <notificationLevel/>
-      <dynamicTriggerConfiguration>True</dynamicTriggerConfiguration>
+      <dynamicTriggerConfiguration>true</dynamicTriggerConfiguration>
       <triggerConfigURL>http://myhost/mytrigger</triggerConfigURL>
       <triggerInformationAction/>
-      <allowTriggeringUnreviewedPatches>false</allowTriggeringUnreviewedPatches>
       <triggerOnEvents>
         <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginCommentAddedEvent>
           <verdictCategory>APRV</verdictCategory>

--- a/tests/triggers/fixtures/gerrit003.xml
+++ b/tests/triggers/fixtures/gerrit003.xml
@@ -52,14 +52,15 @@
       <silentMode>false</silentMode>
       <silentStartMode>false</silentStartMode>
       <escapeQuotes>false</escapeQuotes>
-      <noNameAndEmailParameters>false</noNameAndEmailParameters>
-      <readableMessage>false</readableMessage>
       <dependencyJobsNames/>
+      <commitMessageParameterMode>BASE64</commitMessageParameterMode>
+      <nameAndEmailParameterMode>PLAIN</nameAndEmailParameterMode>
+      <changeSubjectParameterMode>PLAIN</changeSubjectParameterMode>
+      <commentTextParameterMode>BASE64</commentTextParameterMode>
       <notificationLevel/>
-      <dynamicTriggerConfiguration>True</dynamicTriggerConfiguration>
+      <dynamicTriggerConfiguration>true</dynamicTriggerConfiguration>
       <triggerConfigURL>http://myhost/mytrigger</triggerConfigURL>
       <triggerInformationAction/>
-      <allowTriggeringUnreviewedPatches>false</allowTriggeringUnreviewedPatches>
       <triggerOnEvents>
         <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginCommentAddedEvent>
           <verdictCategory>APRV</verdictCategory>

--- a/tests/triggers/fixtures/gerrit004.xml
+++ b/tests/triggers/fixtures/gerrit004.xml
@@ -41,14 +41,15 @@
       <silentMode>false</silentMode>
       <silentStartMode>true</silentStartMode>
       <escapeQuotes>false</escapeQuotes>
-      <noNameAndEmailParameters>false</noNameAndEmailParameters>
-      <readableMessage>false</readableMessage>
       <dependencyJobsNames>job1, job2</dependencyJobsNames>
+      <commitMessageParameterMode>BASE64</commitMessageParameterMode>
+      <nameAndEmailParameterMode>PLAIN</nameAndEmailParameterMode>
+      <changeSubjectParameterMode>PLAIN</changeSubjectParameterMode>
+      <commentTextParameterMode>BASE64</commentTextParameterMode>
       <notificationLevel>ALL</notificationLevel>
-      <dynamicTriggerConfiguration>True</dynamicTriggerConfiguration>
+      <dynamicTriggerConfiguration>true</dynamicTriggerConfiguration>
       <triggerConfigURL>http://myhost/mytrigger</triggerConfigURL>
       <triggerInformationAction/>
-      <allowTriggeringUnreviewedPatches>true</allowTriggeringUnreviewedPatches>
       <triggerOnEvents>
         <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginPatchsetCreatedEvent>
           <excludeDrafts>true</excludeDrafts>

--- a/tests/triggers/fixtures/gerrit004.yaml
+++ b/tests/triggers/fixtures/gerrit004.yaml
@@ -32,11 +32,10 @@ triggers:
       silent: false
       silent-start: true
       escape-quotes: false
-      no-name-and-email: false
       dependency-jobs: 'job1, job2'
+      name-and-email-parameter-mode: PLAIN
       notification-level: ALL
       dynamic-trigger-enabled: true
       dynamic-trigger-url: http://myhost/mytrigger
-      trigger-for-unreviewed-patches: true
       server-name: my-server
       failure-message-file: path/to/filename

--- a/tests/triggers/fixtures/gerrit005.xml
+++ b/tests/triggers/fixtures/gerrit005.xml
@@ -31,14 +31,16 @@
       <silentMode>false</silentMode>
       <silentStartMode>false</silentStartMode>
       <escapeQuotes>true</escapeQuotes>
-      <noNameAndEmailParameters>false</noNameAndEmailParameters>
-      <readableMessage>false</readableMessage>
       <dependencyJobsNames/>
+      <commitMessageParameterMode>BASE64</commitMessageParameterMode>
+      <nameAndEmailParameterMode>PLAIN</nameAndEmailParameterMode>
+      <changeSubjectParameterMode>PLAIN</changeSubjectParameterMode>
+      <commentTextParameterMode>BASE64</commentTextParameterMode>
       <notificationLevel/>
-      <dynamicTriggerConfiguration>False</dynamicTriggerConfiguration>
+      <dynamicTriggerConfiguration>false</dynamicTriggerConfiguration>
       <triggerConfigURL/>
+      <dynamicGerritProjects class="empty-list"/>
       <triggerInformationAction/>
-      <allowTriggeringUnreviewedPatches>false</allowTriggeringUnreviewedPatches>
       <triggerOnEvents>
         <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginCommentAddedEvent>
           <verdictCategory>APRV</verdictCategory>

--- a/tests/triggers/fixtures/gerrit006.xml
+++ b/tests/triggers/fixtures/gerrit006.xml
@@ -31,14 +31,15 @@
       <silentMode>false</silentMode>
       <silentStartMode>false</silentStartMode>
       <escapeQuotes>false</escapeQuotes>
-      <noNameAndEmailParameters>false</noNameAndEmailParameters>
-      <readableMessage>true</readableMessage>
       <dependencyJobsNames/>
+      <commitMessageParameterMode>PLAIN</commitMessageParameterMode>
+      <nameAndEmailParameterMode>PLAIN</nameAndEmailParameterMode>
+      <changeSubjectParameterMode>PLAIN</changeSubjectParameterMode>
+      <commentTextParameterMode>BASE64</commentTextParameterMode>
       <notificationLevel/>
-      <dynamicTriggerConfiguration>True</dynamicTriggerConfiguration>
+      <dynamicTriggerConfiguration>true</dynamicTriggerConfiguration>
       <triggerConfigURL>http://myhost/mytrigger</triggerConfigURL>
       <triggerInformationAction/>
-      <allowTriggeringUnreviewedPatches>false</allowTriggeringUnreviewedPatches>
       <triggerOnEvents>
         <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginCommentAddedContainsEvent>
           <commentAddedCommentContains>recheck</commentAddedCommentContains>

--- a/tests/triggers/fixtures/gerrit007.xml
+++ b/tests/triggers/fixtures/gerrit007.xml
@@ -41,14 +41,15 @@
       <silentMode>false</silentMode>
       <silentStartMode>false</silentStartMode>
       <escapeQuotes>false</escapeQuotes>
-      <noNameAndEmailParameters>false</noNameAndEmailParameters>
-      <readableMessage>false</readableMessage>
       <dependencyJobsNames/>
+      <commitMessageParameterMode>BASE64</commitMessageParameterMode>
+      <nameAndEmailParameterMode>PLAIN</nameAndEmailParameterMode>
+      <changeSubjectParameterMode>PLAIN</changeSubjectParameterMode>
+      <commentTextParameterMode>BASE64</commentTextParameterMode>
       <notificationLevel/>
-      <dynamicTriggerConfiguration>True</dynamicTriggerConfiguration>
+      <dynamicTriggerConfiguration>true</dynamicTriggerConfiguration>
       <triggerConfigURL>http://myhost/mytrigger</triggerConfigURL>
       <triggerInformationAction/>
-      <allowTriggeringUnreviewedPatches>true</allowTriggeringUnreviewedPatches>
       <triggerOnEvents>
         <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginPatchsetCreatedEvent/>
         <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginCommentAddedEvent>

--- a/tests/triggers/fixtures/gerrit008.xml
+++ b/tests/triggers/fixtures/gerrit008.xml
@@ -47,14 +47,15 @@
       <silentMode>false</silentMode>
       <silentStartMode>true</silentStartMode>
       <escapeQuotes>false</escapeQuotes>
-      <noNameAndEmailParameters>false</noNameAndEmailParameters>
-      <readableMessage>false</readableMessage>
       <dependencyJobsNames>job1, job2</dependencyJobsNames>
+      <commitMessageParameterMode>BASE64</commitMessageParameterMode>
+      <nameAndEmailParameterMode>PLAIN</nameAndEmailParameterMode>
+      <changeSubjectParameterMode>PLAIN</changeSubjectParameterMode>
+      <commentTextParameterMode>BASE64</commentTextParameterMode>
       <notificationLevel>ALL</notificationLevel>
-      <dynamicTriggerConfiguration>True</dynamicTriggerConfiguration>
+      <dynamicTriggerConfiguration>true</dynamicTriggerConfiguration>
       <triggerConfigURL>http://myhost/mytrigger</triggerConfigURL>
       <triggerInformationAction/>
-      <allowTriggeringUnreviewedPatches>true</allowTriggeringUnreviewedPatches>
       <triggerOnEvents>
         <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginPatchsetCreatedEvent>
           <excludeDrafts>true</excludeDrafts>

--- a/tests/triggers/fixtures/gerrit010.xml
+++ b/tests/triggers/fixtures/gerrit010.xml
@@ -31,14 +31,15 @@
       <silentMode>false</silentMode>
       <silentStartMode>false</silentStartMode>
       <escapeQuotes>false</escapeQuotes>
-      <noNameAndEmailParameters>false</noNameAndEmailParameters>
-      <readableMessage>false</readableMessage>
       <dependencyJobsNames/>
+      <commitMessageParameterMode>BASE64</commitMessageParameterMode>
+      <nameAndEmailParameterMode>PLAIN</nameAndEmailParameterMode>
+      <changeSubjectParameterMode>PLAIN</changeSubjectParameterMode>
+      <commentTextParameterMode>BASE64</commentTextParameterMode>
       <notificationLevel/>
-      <dynamicTriggerConfiguration>True</dynamicTriggerConfiguration>
+      <dynamicTriggerConfiguration>true</dynamicTriggerConfiguration>
       <triggerConfigURL>http://myhost/mytrigger</triggerConfigURL>
       <triggerInformationAction/>
-      <allowTriggeringUnreviewedPatches>false</allowTriggeringUnreviewedPatches>
       <triggerOnEvents>
         <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginCommentAddedEvent>
           <verdictCategory>APRV</verdictCategory>

--- a/tests/triggers/fixtures/gerrit011-name-and-email-parameter-mode-base64.xml
+++ b/tests/triggers/fixtures/gerrit011-name-and-email-parameter-mode-base64.xml
@@ -15,20 +15,15 @@
       <escapeQuotes>true</escapeQuotes>
       <dependencyJobsNames/>
       <commitMessageParameterMode>BASE64</commitMessageParameterMode>
-      <nameAndEmailParameterMode>PLAIN</nameAndEmailParameterMode>
+      <nameAndEmailParameterMode>BASE64</nameAndEmailParameterMode>
       <changeSubjectParameterMode>PLAIN</changeSubjectParameterMode>
       <commentTextParameterMode>BASE64</commentTextParameterMode>
       <notificationLevel/>
-      <dynamicTriggerConfiguration>true</dynamicTriggerConfiguration>
-      <triggerConfigURL>http://myhost/mytrigger</triggerConfigURL>
+      <dynamicTriggerConfiguration>false</dynamicTriggerConfiguration>
+      <triggerConfigURL/>
+      <dynamicGerritProjects class="empty-list"/>
       <triggerInformationAction/>
-      <triggerOnEvents>
-        <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginCommentAddedEvent>
-          <verdictCategory>APRV</verdictCategory>
-          <commentAddedTriggerApprovalValue>-1</commentAddedTriggerApprovalValue>
-        </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginCommentAddedEvent>
-        <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginChangeAbandonedEvent/>
-      </triggerOnEvents>
+      <triggerOnEvents/>
       <buildStartMessage/>
       <buildFailureMessage/>
       <buildSuccessfulMessage/>

--- a/tests/triggers/fixtures/gerrit011-name-and-email-parameter-mode-base64.yaml
+++ b/tests/triggers/fixtures/gerrit011-name-and-email-parameter-mode-base64.yaml
@@ -1,0 +1,3 @@
+triggers:
+  - gerrit:
+      name-and-email-parameter-mode: BASE64

--- a/tests/triggers/fixtures/gerrit012-name-and-email-parameter-mode-none.xml
+++ b/tests/triggers/fixtures/gerrit012-name-and-email-parameter-mode-none.xml
@@ -15,20 +15,15 @@
       <escapeQuotes>true</escapeQuotes>
       <dependencyJobsNames/>
       <commitMessageParameterMode>BASE64</commitMessageParameterMode>
-      <nameAndEmailParameterMode>PLAIN</nameAndEmailParameterMode>
+      <nameAndEmailParameterMode>NONE</nameAndEmailParameterMode>
       <changeSubjectParameterMode>PLAIN</changeSubjectParameterMode>
       <commentTextParameterMode>BASE64</commentTextParameterMode>
       <notificationLevel/>
-      <dynamicTriggerConfiguration>true</dynamicTriggerConfiguration>
-      <triggerConfigURL>http://myhost/mytrigger</triggerConfigURL>
+      <dynamicTriggerConfiguration>false</dynamicTriggerConfiguration>
+      <triggerConfigURL/>
+      <dynamicGerritProjects class="empty-list"/>
       <triggerInformationAction/>
-      <triggerOnEvents>
-        <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginCommentAddedEvent>
-          <verdictCategory>APRV</verdictCategory>
-          <commentAddedTriggerApprovalValue>-1</commentAddedTriggerApprovalValue>
-        </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginCommentAddedEvent>
-        <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginChangeAbandonedEvent/>
-      </triggerOnEvents>
+      <triggerOnEvents/>
       <buildStartMessage/>
       <buildFailureMessage/>
       <buildSuccessfulMessage/>

--- a/tests/triggers/fixtures/gerrit012-name-and-email-parameter-mode-none.yaml
+++ b/tests/triggers/fixtures/gerrit012-name-and-email-parameter-mode-none.yaml
@@ -1,0 +1,3 @@
+triggers:
+  - gerrit:
+      name-and-email-parameter-mode: NONE

--- a/tests/triggers/fixtures/gerrit013-name-and-email-parameter-mode-plain.xml
+++ b/tests/triggers/fixtures/gerrit013-name-and-email-parameter-mode-plain.xml
@@ -19,16 +19,11 @@
       <changeSubjectParameterMode>PLAIN</changeSubjectParameterMode>
       <commentTextParameterMode>BASE64</commentTextParameterMode>
       <notificationLevel/>
-      <dynamicTriggerConfiguration>true</dynamicTriggerConfiguration>
-      <triggerConfigURL>http://myhost/mytrigger</triggerConfigURL>
+      <dynamicTriggerConfiguration>false</dynamicTriggerConfiguration>
+      <triggerConfigURL/>
+      <dynamicGerritProjects class="empty-list"/>
       <triggerInformationAction/>
-      <triggerOnEvents>
-        <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginCommentAddedEvent>
-          <verdictCategory>APRV</verdictCategory>
-          <commentAddedTriggerApprovalValue>-1</commentAddedTriggerApprovalValue>
-        </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginCommentAddedEvent>
-        <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginChangeAbandonedEvent/>
-      </triggerOnEvents>
+      <triggerOnEvents/>
       <buildStartMessage/>
       <buildFailureMessage/>
       <buildSuccessfulMessage/>

--- a/tests/triggers/fixtures/gerrit013-name-and-email-parameter-mode-plain.yaml
+++ b/tests/triggers/fixtures/gerrit013-name-and-email-parameter-mode-plain.yaml
@@ -1,0 +1,3 @@
+triggers:
+  - gerrit:
+      name-and-email-parameter-mode: PLAIN

--- a/tests/triggers/fixtures/gerrit014-commit-message-parameter-mode-base64.xml
+++ b/tests/triggers/fixtures/gerrit014-commit-message-parameter-mode-base64.xml
@@ -19,16 +19,11 @@
       <changeSubjectParameterMode>PLAIN</changeSubjectParameterMode>
       <commentTextParameterMode>BASE64</commentTextParameterMode>
       <notificationLevel/>
-      <dynamicTriggerConfiguration>true</dynamicTriggerConfiguration>
-      <triggerConfigURL>http://myhost/mytrigger</triggerConfigURL>
+      <dynamicTriggerConfiguration>false</dynamicTriggerConfiguration>
+      <triggerConfigURL/>
+      <dynamicGerritProjects class="empty-list"/>
       <triggerInformationAction/>
-      <triggerOnEvents>
-        <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginCommentAddedEvent>
-          <verdictCategory>APRV</verdictCategory>
-          <commentAddedTriggerApprovalValue>-1</commentAddedTriggerApprovalValue>
-        </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginCommentAddedEvent>
-        <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginChangeAbandonedEvent/>
-      </triggerOnEvents>
+      <triggerOnEvents/>
       <buildStartMessage/>
       <buildFailureMessage/>
       <buildSuccessfulMessage/>

--- a/tests/triggers/fixtures/gerrit014-commit-message-parameter-mode-base64.yaml
+++ b/tests/triggers/fixtures/gerrit014-commit-message-parameter-mode-base64.yaml
@@ -1,0 +1,3 @@
+triggers:
+  - gerrit:
+      commit-message-parameter-mode: BASE64

--- a/tests/triggers/fixtures/gerrit015-commit-message-parameter-mode-plain.xml
+++ b/tests/triggers/fixtures/gerrit015-commit-message-parameter-mode-plain.xml
@@ -14,21 +14,16 @@
       <silentStartMode>false</silentStartMode>
       <escapeQuotes>true</escapeQuotes>
       <dependencyJobsNames/>
-      <commitMessageParameterMode>BASE64</commitMessageParameterMode>
+      <commitMessageParameterMode>PLAIN</commitMessageParameterMode>
       <nameAndEmailParameterMode>PLAIN</nameAndEmailParameterMode>
       <changeSubjectParameterMode>PLAIN</changeSubjectParameterMode>
       <commentTextParameterMode>BASE64</commentTextParameterMode>
       <notificationLevel/>
-      <dynamicTriggerConfiguration>true</dynamicTriggerConfiguration>
-      <triggerConfigURL>http://myhost/mytrigger</triggerConfigURL>
+      <dynamicTriggerConfiguration>false</dynamicTriggerConfiguration>
+      <triggerConfigURL/>
+      <dynamicGerritProjects class="empty-list"/>
       <triggerInformationAction/>
-      <triggerOnEvents>
-        <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginCommentAddedEvent>
-          <verdictCategory>APRV</verdictCategory>
-          <commentAddedTriggerApprovalValue>-1</commentAddedTriggerApprovalValue>
-        </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginCommentAddedEvent>
-        <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginChangeAbandonedEvent/>
-      </triggerOnEvents>
+      <triggerOnEvents/>
       <buildStartMessage/>
       <buildFailureMessage/>
       <buildSuccessfulMessage/>

--- a/tests/triggers/fixtures/gerrit015-commit-message-parameter-mode-plain.yaml
+++ b/tests/triggers/fixtures/gerrit015-commit-message-parameter-mode-plain.yaml
@@ -1,0 +1,3 @@
+triggers:
+  - gerrit:
+      commit-message-parameter-mode: PLAIN

--- a/tests/triggers/fixtures/gerrit016-commit-message-parameter-mode-none.xml
+++ b/tests/triggers/fixtures/gerrit016-commit-message-parameter-mode-none.xml
@@ -14,21 +14,16 @@
       <silentStartMode>false</silentStartMode>
       <escapeQuotes>true</escapeQuotes>
       <dependencyJobsNames/>
-      <commitMessageParameterMode>BASE64</commitMessageParameterMode>
+      <commitMessageParameterMode>NONE</commitMessageParameterMode>
       <nameAndEmailParameterMode>PLAIN</nameAndEmailParameterMode>
       <changeSubjectParameterMode>PLAIN</changeSubjectParameterMode>
       <commentTextParameterMode>BASE64</commentTextParameterMode>
       <notificationLevel/>
-      <dynamicTriggerConfiguration>true</dynamicTriggerConfiguration>
-      <triggerConfigURL>http://myhost/mytrigger</triggerConfigURL>
+      <dynamicTriggerConfiguration>false</dynamicTriggerConfiguration>
+      <triggerConfigURL/>
+      <dynamicGerritProjects class="empty-list"/>
       <triggerInformationAction/>
-      <triggerOnEvents>
-        <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginCommentAddedEvent>
-          <verdictCategory>APRV</verdictCategory>
-          <commentAddedTriggerApprovalValue>-1</commentAddedTriggerApprovalValue>
-        </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginCommentAddedEvent>
-        <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginChangeAbandonedEvent/>
-      </triggerOnEvents>
+      <triggerOnEvents/>
       <buildStartMessage/>
       <buildFailureMessage/>
       <buildSuccessfulMessage/>

--- a/tests/triggers/fixtures/gerrit016-commit-message-parameter-mode-none.yaml
+++ b/tests/triggers/fixtures/gerrit016-commit-message-parameter-mode-none.yaml
@@ -1,0 +1,3 @@
+triggers:
+  - gerrit:
+      commit-message-parameter-mode: NONE

--- a/tests/triggers/fixtures/gerrit017-change-subject-parameter-mode-base64.xml
+++ b/tests/triggers/fixtures/gerrit017-change-subject-parameter-mode-base64.xml
@@ -16,19 +16,14 @@
       <dependencyJobsNames/>
       <commitMessageParameterMode>BASE64</commitMessageParameterMode>
       <nameAndEmailParameterMode>PLAIN</nameAndEmailParameterMode>
-      <changeSubjectParameterMode>PLAIN</changeSubjectParameterMode>
+      <changeSubjectParameterMode>BASE64</changeSubjectParameterMode>
       <commentTextParameterMode>BASE64</commentTextParameterMode>
       <notificationLevel/>
-      <dynamicTriggerConfiguration>true</dynamicTriggerConfiguration>
-      <triggerConfigURL>http://myhost/mytrigger</triggerConfigURL>
+      <dynamicTriggerConfiguration>false</dynamicTriggerConfiguration>
+      <triggerConfigURL/>
+      <dynamicGerritProjects class="empty-list"/>
       <triggerInformationAction/>
-      <triggerOnEvents>
-        <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginCommentAddedEvent>
-          <verdictCategory>APRV</verdictCategory>
-          <commentAddedTriggerApprovalValue>-1</commentAddedTriggerApprovalValue>
-        </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginCommentAddedEvent>
-        <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginChangeAbandonedEvent/>
-      </triggerOnEvents>
+      <triggerOnEvents/>
       <buildStartMessage/>
       <buildFailureMessage/>
       <buildSuccessfulMessage/>

--- a/tests/triggers/fixtures/gerrit017-change-subject-parameter-mode-base64.yaml
+++ b/tests/triggers/fixtures/gerrit017-change-subject-parameter-mode-base64.yaml
@@ -1,0 +1,3 @@
+triggers:
+  - gerrit:
+      change-subject-parameter-mode: BASE64

--- a/tests/triggers/fixtures/gerrit018-change-subject-parameter-mode-plain.xml
+++ b/tests/triggers/fixtures/gerrit018-change-subject-parameter-mode-plain.xml
@@ -19,16 +19,11 @@
       <changeSubjectParameterMode>PLAIN</changeSubjectParameterMode>
       <commentTextParameterMode>BASE64</commentTextParameterMode>
       <notificationLevel/>
-      <dynamicTriggerConfiguration>true</dynamicTriggerConfiguration>
-      <triggerConfigURL>http://myhost/mytrigger</triggerConfigURL>
+      <dynamicTriggerConfiguration>false</dynamicTriggerConfiguration>
+      <triggerConfigURL/>
+      <dynamicGerritProjects class="empty-list"/>
       <triggerInformationAction/>
-      <triggerOnEvents>
-        <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginCommentAddedEvent>
-          <verdictCategory>APRV</verdictCategory>
-          <commentAddedTriggerApprovalValue>-1</commentAddedTriggerApprovalValue>
-        </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginCommentAddedEvent>
-        <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginChangeAbandonedEvent/>
-      </triggerOnEvents>
+      <triggerOnEvents/>
       <buildStartMessage/>
       <buildFailureMessage/>
       <buildSuccessfulMessage/>

--- a/tests/triggers/fixtures/gerrit018-change-subject-parameter-mode-plain.yaml
+++ b/tests/triggers/fixtures/gerrit018-change-subject-parameter-mode-plain.yaml
@@ -1,0 +1,3 @@
+triggers:
+  - gerrit:
+      change-subject-parameter-mode: PLAIN

--- a/tests/triggers/fixtures/gerrit019-change-subject-parameter-mode-none.xml
+++ b/tests/triggers/fixtures/gerrit019-change-subject-parameter-mode-none.xml
@@ -16,19 +16,14 @@
       <dependencyJobsNames/>
       <commitMessageParameterMode>BASE64</commitMessageParameterMode>
       <nameAndEmailParameterMode>PLAIN</nameAndEmailParameterMode>
-      <changeSubjectParameterMode>PLAIN</changeSubjectParameterMode>
+      <changeSubjectParameterMode>NONE</changeSubjectParameterMode>
       <commentTextParameterMode>BASE64</commentTextParameterMode>
       <notificationLevel/>
-      <dynamicTriggerConfiguration>true</dynamicTriggerConfiguration>
-      <triggerConfigURL>http://myhost/mytrigger</triggerConfigURL>
+      <dynamicTriggerConfiguration>false</dynamicTriggerConfiguration>
+      <triggerConfigURL/>
+      <dynamicGerritProjects class="empty-list"/>
       <triggerInformationAction/>
-      <triggerOnEvents>
-        <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginCommentAddedEvent>
-          <verdictCategory>APRV</verdictCategory>
-          <commentAddedTriggerApprovalValue>-1</commentAddedTriggerApprovalValue>
-        </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginCommentAddedEvent>
-        <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginChangeAbandonedEvent/>
-      </triggerOnEvents>
+      <triggerOnEvents/>
       <buildStartMessage/>
       <buildFailureMessage/>
       <buildSuccessfulMessage/>

--- a/tests/triggers/fixtures/gerrit019-change-subject-parameter-mode-none.yaml
+++ b/tests/triggers/fixtures/gerrit019-change-subject-parameter-mode-none.yaml
@@ -1,0 +1,3 @@
+triggers:
+  - gerrit:
+      change-subject-parameter-mode: NONE

--- a/tests/triggers/fixtures/gerrit020-comment-text-parameter-mode-base64.xml
+++ b/tests/triggers/fixtures/gerrit020-comment-text-parameter-mode-base64.xml
@@ -19,16 +19,11 @@
       <changeSubjectParameterMode>PLAIN</changeSubjectParameterMode>
       <commentTextParameterMode>BASE64</commentTextParameterMode>
       <notificationLevel/>
-      <dynamicTriggerConfiguration>true</dynamicTriggerConfiguration>
-      <triggerConfigURL>http://myhost/mytrigger</triggerConfigURL>
+      <dynamicTriggerConfiguration>false</dynamicTriggerConfiguration>
+      <triggerConfigURL/>
+      <dynamicGerritProjects class="empty-list"/>
       <triggerInformationAction/>
-      <triggerOnEvents>
-        <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginCommentAddedEvent>
-          <verdictCategory>APRV</verdictCategory>
-          <commentAddedTriggerApprovalValue>-1</commentAddedTriggerApprovalValue>
-        </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginCommentAddedEvent>
-        <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginChangeAbandonedEvent/>
-      </triggerOnEvents>
+      <triggerOnEvents/>
       <buildStartMessage/>
       <buildFailureMessage/>
       <buildSuccessfulMessage/>

--- a/tests/triggers/fixtures/gerrit020-comment-text-parameter-mode-base64.yaml
+++ b/tests/triggers/fixtures/gerrit020-comment-text-parameter-mode-base64.yaml
@@ -1,0 +1,3 @@
+triggers:
+  - gerrit:
+      comment-text-parameter-mode: BASE64

--- a/tests/triggers/fixtures/gerrit021-comment-text-parameter-mode-plain.xml
+++ b/tests/triggers/fixtures/gerrit021-comment-text-parameter-mode-plain.xml
@@ -17,18 +17,13 @@
       <commitMessageParameterMode>BASE64</commitMessageParameterMode>
       <nameAndEmailParameterMode>PLAIN</nameAndEmailParameterMode>
       <changeSubjectParameterMode>PLAIN</changeSubjectParameterMode>
-      <commentTextParameterMode>BASE64</commentTextParameterMode>
+      <commentTextParameterMode>PLAIN</commentTextParameterMode>
       <notificationLevel/>
-      <dynamicTriggerConfiguration>true</dynamicTriggerConfiguration>
-      <triggerConfigURL>http://myhost/mytrigger</triggerConfigURL>
+      <dynamicTriggerConfiguration>false</dynamicTriggerConfiguration>
+      <triggerConfigURL/>
+      <dynamicGerritProjects class="empty-list"/>
       <triggerInformationAction/>
-      <triggerOnEvents>
-        <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginCommentAddedEvent>
-          <verdictCategory>APRV</verdictCategory>
-          <commentAddedTriggerApprovalValue>-1</commentAddedTriggerApprovalValue>
-        </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginCommentAddedEvent>
-        <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginChangeAbandonedEvent/>
-      </triggerOnEvents>
+      <triggerOnEvents/>
       <buildStartMessage/>
       <buildFailureMessage/>
       <buildSuccessfulMessage/>

--- a/tests/triggers/fixtures/gerrit021-comment-text-parameter-mode-plain.yaml
+++ b/tests/triggers/fixtures/gerrit021-comment-text-parameter-mode-plain.yaml
@@ -1,0 +1,3 @@
+triggers:
+  - gerrit:
+      comment-text-parameter-mode: PLAIN

--- a/tests/triggers/fixtures/gerrit022-comment-text-parameter-mode-none.xml
+++ b/tests/triggers/fixtures/gerrit022-comment-text-parameter-mode-none.xml
@@ -17,18 +17,13 @@
       <commitMessageParameterMode>BASE64</commitMessageParameterMode>
       <nameAndEmailParameterMode>PLAIN</nameAndEmailParameterMode>
       <changeSubjectParameterMode>PLAIN</changeSubjectParameterMode>
-      <commentTextParameterMode>BASE64</commentTextParameterMode>
+      <commentTextParameterMode>NONE</commentTextParameterMode>
       <notificationLevel/>
-      <dynamicTriggerConfiguration>true</dynamicTriggerConfiguration>
-      <triggerConfigURL>http://myhost/mytrigger</triggerConfigURL>
+      <dynamicTriggerConfiguration>false</dynamicTriggerConfiguration>
+      <triggerConfigURL/>
+      <dynamicGerritProjects class="empty-list"/>
       <triggerInformationAction/>
-      <triggerOnEvents>
-        <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginCommentAddedEvent>
-          <verdictCategory>APRV</verdictCategory>
-          <commentAddedTriggerApprovalValue>-1</commentAddedTriggerApprovalValue>
-        </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginCommentAddedEvent>
-        <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginChangeAbandonedEvent/>
-      </triggerOnEvents>
+      <triggerOnEvents/>
       <buildStartMessage/>
       <buildFailureMessage/>
       <buildSuccessfulMessage/>

--- a/tests/triggers/fixtures/gerrit022-comment-text-parameter-mode-none.yaml
+++ b/tests/triggers/fixtures/gerrit022-comment-text-parameter-mode-none.yaml
@@ -1,0 +1,3 @@
+triggers:
+  - gerrit:
+      comment-text-parameter-mode: NONE

--- a/tests/triggers/fixtures/gerrit023-no-name-and-email-lt-2.18.plugins_info.yaml
+++ b/tests/triggers/fixtures/gerrit023-no-name-and-email-lt-2.18.plugins_info.yaml
@@ -1,0 +1,3 @@
+- longName: 'Gerrit Trigger'
+  shortName: 'gerrit-trigger'
+  version: '2.17.0'

--- a/tests/triggers/fixtures/gerrit023-no-name-and-email-lt-2.18.xml
+++ b/tests/triggers/fixtures/gerrit023-no-name-and-email-lt-2.18.xml
@@ -14,21 +14,14 @@
       <silentStartMode>false</silentStartMode>
       <escapeQuotes>true</escapeQuotes>
       <dependencyJobsNames/>
-      <commitMessageParameterMode>BASE64</commitMessageParameterMode>
-      <nameAndEmailParameterMode>PLAIN</nameAndEmailParameterMode>
-      <changeSubjectParameterMode>PLAIN</changeSubjectParameterMode>
-      <commentTextParameterMode>BASE64</commentTextParameterMode>
+      <noNameAndEmailParameters>true</noNameAndEmailParameters>
+      <readableMessage>false</readableMessage>
       <notificationLevel/>
-      <dynamicTriggerConfiguration>true</dynamicTriggerConfiguration>
-      <triggerConfigURL>http://myhost/mytrigger</triggerConfigURL>
+      <dynamicTriggerConfiguration>false</dynamicTriggerConfiguration>
+      <triggerConfigURL/>
+      <dynamicGerritProjects class="empty-list"/>
       <triggerInformationAction/>
-      <triggerOnEvents>
-        <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginCommentAddedEvent>
-          <verdictCategory>APRV</verdictCategory>
-          <commentAddedTriggerApprovalValue>-1</commentAddedTriggerApprovalValue>
-        </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginCommentAddedEvent>
-        <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginChangeAbandonedEvent/>
-      </triggerOnEvents>
+      <triggerOnEvents/>
       <buildStartMessage/>
       <buildFailureMessage/>
       <buildSuccessfulMessage/>

--- a/tests/triggers/fixtures/gerrit023-no-name-and-email-lt-2.18.yaml
+++ b/tests/triggers/fixtures/gerrit023-no-name-and-email-lt-2.18.yaml
@@ -1,0 +1,3 @@
+triggers:
+  - gerrit:
+      no-name-and-email: true

--- a/tests/triggers/fixtures/gerrit024-no-name-and-email-ge-2.18.plugins_info.yaml
+++ b/tests/triggers/fixtures/gerrit024-no-name-and-email-ge-2.18.plugins_info.yaml
@@ -1,0 +1,3 @@
+- longName: 'Gerrit Trigger'
+  shortName: 'gerrit-trigger'
+  version: '2.18.0'

--- a/tests/triggers/fixtures/gerrit024-no-name-and-email-ge-2.18.xml
+++ b/tests/triggers/fixtures/gerrit024-no-name-and-email-ge-2.18.xml
@@ -15,20 +15,15 @@
       <escapeQuotes>true</escapeQuotes>
       <dependencyJobsNames/>
       <commitMessageParameterMode>BASE64</commitMessageParameterMode>
-      <nameAndEmailParameterMode>PLAIN</nameAndEmailParameterMode>
+      <nameAndEmailParameterMode>NONE</nameAndEmailParameterMode>
       <changeSubjectParameterMode>PLAIN</changeSubjectParameterMode>
       <commentTextParameterMode>BASE64</commentTextParameterMode>
       <notificationLevel/>
-      <dynamicTriggerConfiguration>true</dynamicTriggerConfiguration>
-      <triggerConfigURL>http://myhost/mytrigger</triggerConfigURL>
+      <dynamicTriggerConfiguration>false</dynamicTriggerConfiguration>
+      <triggerConfigURL/>
+      <dynamicGerritProjects class="empty-list"/>
       <triggerInformationAction/>
-      <triggerOnEvents>
-        <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginCommentAddedEvent>
-          <verdictCategory>APRV</verdictCategory>
-          <commentAddedTriggerApprovalValue>-1</commentAddedTriggerApprovalValue>
-        </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginCommentAddedEvent>
-        <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginChangeAbandonedEvent/>
-      </triggerOnEvents>
+      <triggerOnEvents/>
       <buildStartMessage/>
       <buildFailureMessage/>
       <buildSuccessfulMessage/>

--- a/tests/triggers/fixtures/gerrit024-no-name-and-email-ge-2.18.yaml
+++ b/tests/triggers/fixtures/gerrit024-no-name-and-email-ge-2.18.yaml
@@ -1,0 +1,3 @@
+triggers:
+  - gerrit:
+      no-name-and-email: true

--- a/tests/triggers/fixtures/gerrit025-readable-message-lt-2.18.plugins_info.yaml
+++ b/tests/triggers/fixtures/gerrit025-readable-message-lt-2.18.plugins_info.yaml
@@ -1,0 +1,3 @@
+- longName: 'Gerrit Trigger'
+  shortName: 'gerrit-trigger'
+  version: '2.17.0'

--- a/tests/triggers/fixtures/gerrit025-readable-message-lt-2.18.xml
+++ b/tests/triggers/fixtures/gerrit025-readable-message-lt-2.18.xml
@@ -14,21 +14,14 @@
       <silentStartMode>false</silentStartMode>
       <escapeQuotes>true</escapeQuotes>
       <dependencyJobsNames/>
-      <commitMessageParameterMode>BASE64</commitMessageParameterMode>
-      <nameAndEmailParameterMode>PLAIN</nameAndEmailParameterMode>
-      <changeSubjectParameterMode>PLAIN</changeSubjectParameterMode>
-      <commentTextParameterMode>BASE64</commentTextParameterMode>
+      <noNameAndEmailParameters>false</noNameAndEmailParameters>
+      <readableMessage>true</readableMessage>
       <notificationLevel/>
-      <dynamicTriggerConfiguration>true</dynamicTriggerConfiguration>
-      <triggerConfigURL>http://myhost/mytrigger</triggerConfigURL>
+      <dynamicTriggerConfiguration>false</dynamicTriggerConfiguration>
+      <triggerConfigURL/>
+      <dynamicGerritProjects class="empty-list"/>
       <triggerInformationAction/>
-      <triggerOnEvents>
-        <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginCommentAddedEvent>
-          <verdictCategory>APRV</verdictCategory>
-          <commentAddedTriggerApprovalValue>-1</commentAddedTriggerApprovalValue>
-        </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginCommentAddedEvent>
-        <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginChangeAbandonedEvent/>
-      </triggerOnEvents>
+      <triggerOnEvents/>
       <buildStartMessage/>
       <buildFailureMessage/>
       <buildSuccessfulMessage/>

--- a/tests/triggers/fixtures/gerrit025-readable-message-lt-2.18.yaml
+++ b/tests/triggers/fixtures/gerrit025-readable-message-lt-2.18.yaml
@@ -1,0 +1,3 @@
+triggers:
+  - gerrit:
+      readable-message: true

--- a/tests/triggers/fixtures/gerrit026-readable-message-ge-2.18.plugins_info.yaml
+++ b/tests/triggers/fixtures/gerrit026-readable-message-ge-2.18.plugins_info.yaml
@@ -1,0 +1,3 @@
+- longName: 'Gerrit Trigger'
+  shortName: 'gerrit-trigger'
+  version: '2.18.0'

--- a/tests/triggers/fixtures/gerrit026-readable-message-ge-2.18.xml
+++ b/tests/triggers/fixtures/gerrit026-readable-message-ge-2.18.xml
@@ -14,21 +14,16 @@
       <silentStartMode>false</silentStartMode>
       <escapeQuotes>true</escapeQuotes>
       <dependencyJobsNames/>
-      <commitMessageParameterMode>BASE64</commitMessageParameterMode>
+      <commitMessageParameterMode>PLAIN</commitMessageParameterMode>
       <nameAndEmailParameterMode>PLAIN</nameAndEmailParameterMode>
       <changeSubjectParameterMode>PLAIN</changeSubjectParameterMode>
       <commentTextParameterMode>BASE64</commentTextParameterMode>
       <notificationLevel/>
-      <dynamicTriggerConfiguration>true</dynamicTriggerConfiguration>
-      <triggerConfigURL>http://myhost/mytrigger</triggerConfigURL>
+      <dynamicTriggerConfiguration>false</dynamicTriggerConfiguration>
+      <triggerConfigURL/>
+      <dynamicGerritProjects class="empty-list"/>
       <triggerInformationAction/>
-      <triggerOnEvents>
-        <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginCommentAddedEvent>
-          <verdictCategory>APRV</verdictCategory>
-          <commentAddedTriggerApprovalValue>-1</commentAddedTriggerApprovalValue>
-        </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginCommentAddedEvent>
-        <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginChangeAbandonedEvent/>
-      </triggerOnEvents>
+      <triggerOnEvents/>
       <buildStartMessage/>
       <buildFailureMessage/>
       <buildSuccessfulMessage/>

--- a/tests/triggers/fixtures/gerrit026-readable-message-ge-2.18.yaml
+++ b/tests/triggers/fixtures/gerrit026-readable-message-ge-2.18.yaml
@@ -1,0 +1,3 @@
+triggers:
+  - gerrit:
+      readable-message: true

--- a/tests/triggers/fixtures/gerrit027-trigger-for-unreviewed-patches.plugins_info.yaml
+++ b/tests/triggers/fixtures/gerrit027-trigger-for-unreviewed-patches.plugins_info.yaml
@@ -1,0 +1,3 @@
+- longName: 'Gerrit Trigger'
+  shortName: 'gerrit-trigger'
+  version: '2.13.0'

--- a/tests/triggers/fixtures/gerrit027-trigger-for-unreviewed-patches.xml
+++ b/tests/triggers/fixtures/gerrit027-trigger-for-unreviewed-patches.xml
@@ -14,21 +14,15 @@
       <silentStartMode>false</silentStartMode>
       <escapeQuotes>true</escapeQuotes>
       <dependencyJobsNames/>
-      <commitMessageParameterMode>BASE64</commitMessageParameterMode>
-      <nameAndEmailParameterMode>PLAIN</nameAndEmailParameterMode>
-      <changeSubjectParameterMode>PLAIN</changeSubjectParameterMode>
-      <commentTextParameterMode>BASE64</commentTextParameterMode>
+      <noNameAndEmailParameters>false</noNameAndEmailParameters>
+      <readableMessage>false</readableMessage>
       <notificationLevel/>
-      <dynamicTriggerConfiguration>true</dynamicTriggerConfiguration>
-      <triggerConfigURL>http://myhost/mytrigger</triggerConfigURL>
+      <dynamicTriggerConfiguration>false</dynamicTriggerConfiguration>
+      <triggerConfigURL/>
+      <dynamicGerritProjects class="empty-list"/>
       <triggerInformationAction/>
-      <triggerOnEvents>
-        <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginCommentAddedEvent>
-          <verdictCategory>APRV</verdictCategory>
-          <commentAddedTriggerApprovalValue>-1</commentAddedTriggerApprovalValue>
-        </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginCommentAddedEvent>
-        <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginChangeAbandonedEvent/>
-      </triggerOnEvents>
+      <allowTriggeringUnreviewedPatches>true</allowTriggeringUnreviewedPatches>
+      <triggerOnEvents/>
       <buildStartMessage/>
       <buildFailureMessage/>
       <buildSuccessfulMessage/>

--- a/tests/triggers/fixtures/gerrit027-trigger-for-unreviewed-patches.yaml
+++ b/tests/triggers/fixtures/gerrit027-trigger-for-unreviewed-patches.yaml
@@ -1,0 +1,3 @@
+triggers:
+  - gerrit:
+      trigger-for-unreviewed-patches: true

--- a/tests/yamlparser/fixtures/complete001.xml
+++ b/tests/yamlparser/fixtures/complete001.xml
@@ -69,14 +69,16 @@
       <silentMode>false</silentMode>
       <silentStartMode>false</silentStartMode>
       <escapeQuotes>true</escapeQuotes>
-      <noNameAndEmailParameters>false</noNameAndEmailParameters>
-      <readableMessage>false</readableMessage>
       <dependencyJobsNames/>
+      <commitMessageParameterMode>BASE64</commitMessageParameterMode>
+      <nameAndEmailParameterMode>PLAIN</nameAndEmailParameterMode>
+      <changeSubjectParameterMode>PLAIN</changeSubjectParameterMode>
+      <commentTextParameterMode>BASE64</commentTextParameterMode>
       <notificationLevel/>
-      <dynamicTriggerConfiguration>False</dynamicTriggerConfiguration>
+      <dynamicTriggerConfiguration>false</dynamicTriggerConfiguration>
       <triggerConfigURL/>
+      <dynamicGerritProjects class="empty-list"/>
       <triggerInformationAction/>
-      <allowTriggeringUnreviewedPatches>false</allowTriggeringUnreviewedPatches>
       <triggerOnEvents>
         <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginPatchsetCreatedEvent/>
       </triggerOnEvents>


### PR DESCRIPTION
The changes include:

- deprecated the following options and made support for them dependent
  on the Gerrit Trigger plugin version:
  - `no-name-and-email`
  - `readable-message`
  - `trigger-for-unreviewed-patches`

- added a set of new options:
  - `name-and-email-parameter-mode` (replaced `no-name-and-email`)
  - `commit-message-parameter-mode` (replaced `readable-message`)
  - `change-subject-parameter-mode`
  - `comment-text-parameter-mode`
  all these options can have one of the following values:
  - `NONE`
  - `PLAIN`
  - `BASE64`
  the default value for the first two options is taken from the
  respective options they replaced, if they exist in the input YAML
  file, so the overall change should be backward compatible

- fixed the value generated for `<dynamicTriggerConfiguration>` element
  it should be `true`/`false` instead of `True`/`False`

- added an empty `<dynamicGerritProjects>` element when dynamic trigger
  functionality is disabled to match what the plugin does

With the above changes the markup generated by JJB is fully aligned with
Gerrit Trigger plugin v2.30.x. Tested on Gerrit Trigger plugin v2.30.0.