### PR TITLE
Removed the unnecessary empty combinationFilter Tag

### DIFF
--- a/jenkins_jobs/modules/project_matrix.py
+++ b/jenkins_jobs/modules/project_matrix.py
@@ -162,9 +162,10 @@ class Matrix(jenkins_jobs.modules.base.Base):
         strategy = data.get(strategy_name, {})
 
         if strategy_name == "execution-strategy":
-            XML.SubElement(root, "combinationFilter").text = str(
-                strategy.get("combination-filter", "")
-            ).rstrip()
+            if "combination-filter" in strategy:
+                XML.SubElement(root, "combinationFilter").text = str(
+                    strategy.get("combination-filter", "")
+                ).rstrip()
             XML.SubElement(ex_r, "runSequentially").text = str(
                 strategy.get("sequential", False)
             ).lower()

--- a/tests/cmd/fixtures/multi-path/output_recursive/job4
+++ b/tests/cmd/fixtures/multi-path/output_recursive/job4
@@ -3,7 +3,6 @@
   <executionStrategy class="hudson.matrix.DefaultMatrixExecutionStrategyImpl">
     <runSequentially>false</runSequentially>
   </executionStrategy>
-  <combinationFilter/>
   <axes/>
   <actions/>
   <description>&lt;!-- Managed by Jenkins Job Builder --&gt;</description>

--- a/tests/general/fixtures/custom-workspace002.xml
+++ b/tests/general/fixtures/custom-workspace002.xml
@@ -3,7 +3,6 @@
   <executionStrategy class="hudson.matrix.DefaultMatrixExecutionStrategyImpl">
     <runSequentially>false</runSequentially>
   </executionStrategy>
-  <combinationFilter/>
   <axes/>
   <actions/>
   <keepDependencies>false</keepDependencies>

--- a/tests/general/fixtures/matrix-axis-yaml.xml
+++ b/tests/general/fixtures/matrix-axis-yaml.xml
@@ -3,7 +3,6 @@
   <executionStrategy class="hudson.matrix.DefaultMatrixExecutionStrategyImpl">
     <runSequentially>false</runSequentially>
   </executionStrategy>
-  <combinationFilter/>
   <axes>
     <org.jenkinsci.plugins.yamlaxis.YamlAxis>
       <name>python</name>

--- a/tests/general/fixtures/matrix-axis001.xml
+++ b/tests/general/fixtures/matrix-axis001.xml
@@ -3,7 +3,6 @@
   <executionStrategy class="hudson.matrix.DefaultMatrixExecutionStrategyImpl">
     <runSequentially>false</runSequentially>
   </executionStrategy>
-  <combinationFilter/>
   <axes>
     <ca.silvermaplesolutions.jenkins.plugins.daxis.DynamicAxis>
       <name>config</name>

--- a/tests/general/fixtures/matrix-axis002.xml
+++ b/tests/general/fixtures/matrix-axis002.xml
@@ -3,7 +3,6 @@
   <executionStrategy class="hudson.matrix.DefaultMatrixExecutionStrategyImpl">
     <runSequentially>false</runSequentially>
   </executionStrategy>
-  <combinationFilter/>
   <axes>
     <ca.silvermaplesolutions.jenkins.plugins.daxis.DynamicAxis>
       <name>config</name>

--- a/tests/general/fixtures/matrix-axis003.xml
+++ b/tests/general/fixtures/matrix-axis003.xml
@@ -3,7 +3,6 @@
   <executionStrategy class="hudson.matrix.DefaultMatrixExecutionStrategyImpl">
     <runSequentially>false</runSequentially>
   </executionStrategy>
-  <combinationFilter/>
   <axes>
     <jenkins.plugins.shiningpanda.matrix.PythonAxis>
       <name>PYTHON</name>

--- a/tests/general/fixtures/matrix-axis004.xml
+++ b/tests/general/fixtures/matrix-axis004.xml
@@ -3,7 +3,6 @@
   <executionStrategy class="hudson.matrix.DefaultMatrixExecutionStrategyImpl">
     <runSequentially>false</runSequentially>
   </executionStrategy>
-  <combinationFilter/>
   <axes>
     <hudson.matrix.JDKAxis>
       <name>jdk</name>

--- a/tests/general/fixtures/matrix-axis005.xml
+++ b/tests/general/fixtures/matrix-axis005.xml
@@ -3,7 +3,6 @@
   <executionStrategy class="hudson.matrix.DefaultMatrixExecutionStrategyImpl">
     <runSequentially>false</runSequentially>
   </executionStrategy>
-  <combinationFilter/>
   <axes>
     <ca.silvermaplesolutions.jenkins.plugins.daxis.DynamicAxis>
       <name>config</name>

--- a/tests/general/fixtures/project-type002.xml
+++ b/tests/general/fixtures/project-type002.xml
@@ -3,7 +3,6 @@
   <executionStrategy class="hudson.matrix.DefaultMatrixExecutionStrategyImpl">
     <runSequentially>false</runSequentially>
   </executionStrategy>
-  <combinationFilter/>
   <axes/>
   <actions/>
   <keepDependencies>false</keepDependencies>

--- a/tests/wrappers/fixtures/matrix-tie-parent.xml
+++ b/tests/wrappers/fixtures/matrix-tie-parent.xml
@@ -3,7 +3,6 @@
   <executionStrategy class="hudson.matrix.DefaultMatrixExecutionStrategyImpl">
     <runSequentially>false</runSequentially>
   </executionStrategy>
-  <combinationFilter/>
   <axes/>
   <buildWrappers>
     <matrixtieparent.BuildWrapperMtp>

--- a/tests/yamlparser/fixtures/custom_distri.xml
+++ b/tests/yamlparser/fixtures/custom_distri.xml
@@ -3,7 +3,6 @@
   <executionStrategy class="hudson.matrix.DefaultMatrixExecutionStrategyImpl">
     <runSequentially>false</runSequentially>
   </executionStrategy>
-  <combinationFilter/>
   <axes>
     <hudson.matrix.TextAxis>
       <name>distribution</name>

--- a/tests/yamlparser/fixtures/expand-yaml-for-template-job/dimensionality-test001.xml
+++ b/tests/yamlparser/fixtures/expand-yaml-for-template-job/dimensionality-test001.xml
@@ -3,7 +3,6 @@
   <executionStrategy class="hudson.matrix.DefaultMatrixExecutionStrategyImpl">
     <runSequentially>false</runSequentially>
   </executionStrategy>
-  <combinationFilter/>
   <axes>
     <hudson.matrix.TextAxis>
       <name>PLATFORM</name>
@@ -32,7 +31,6 @@
   <executionStrategy class="hudson.matrix.DefaultMatrixExecutionStrategyImpl">
     <runSequentially>false</runSequentially>
   </executionStrategy>
-  <combinationFilter/>
   <axes>
     <hudson.matrix.TextAxis>
       <name>PLATFORM</name>
@@ -61,7 +59,6 @@
   <executionStrategy class="hudson.matrix.DefaultMatrixExecutionStrategyImpl">
     <runSequentially>false</runSequentially>
   </executionStrategy>
-  <combinationFilter/>
   <axes>
     <hudson.matrix.TextAxis>
       <name>PLATFORM</name>

--- a/tests/yamlparser/fixtures/project-matrix002.xml
+++ b/tests/yamlparser/fixtures/project-matrix002.xml
@@ -9,7 +9,6 @@
       <color>BLUE</color>
     </touchStoneResultCondition>
   </executionStrategy>
-  <combinationFilter/>
   <axes/>
   <actions/>
   <description>&lt;!-- Managed by Jenkins Job Builder --&gt;</description>

--- a/tests/yamlparser/fixtures/trigger_parameterized_builds/parameter-override-ordering-003.xml
+++ b/tests/yamlparser/fixtures/trigger_parameterized_builds/parameter-override-ordering-003.xml
@@ -3,7 +3,6 @@
   <executionStrategy class="hudson.matrix.DefaultMatrixExecutionStrategyImpl">
     <runSequentially>false</runSequentially>
   </executionStrategy>
-  <combinationFilter/>
   <axes>
     <hudson.matrix.TextAxis>
       <name>foo_bar</name>
@@ -45,7 +44,6 @@
   <executionStrategy class="hudson.matrix.DefaultMatrixExecutionStrategyImpl">
     <runSequentially>false</runSequentially>
   </executionStrategy>
-  <combinationFilter/>
   <axes>
     <hudson.matrix.TextAxis>
       <name>foo_bar</name>


### PR DESCRIPTION
In the current implementation, jjb creates an empty
combinationFilter tag whenever there is `executionStrategy`.
This empty tag should not appear.