### PR TITLE
Fix Authorization Matrix property support on jobs in a folder (v2)

### DIFF
--- a/jenkins_jobs/modules/properties.py
+++ b/jenkins_jobs/modules/properties.py
@@ -1,4 +1,5 @@
 # Copyright 2012 Hewlett-Packard Development Company, L.P.
+# Copyright 2020 Liberty Global B.V.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -1274,7 +1275,10 @@ class Properties(jenkins_jobs.modules.base.Base):
                         prop["authorization"]["_use_folder_perms"] = True
                         prop["authorization"]["_is_a_folder"] = True
                     else:
-                        prop["authorization"]["_use_folder_perms"] = "folder" in data
+                        job_in_folder = ("folder" in data) or (
+                            "/" in data.get("name", "")
+                        )
+                        prop["authorization"]["_use_folder_perms"] = job_in_folder
                         prop["authorization"]["_is_a_folder"] = False
                 else:
                     prop["authorization"]["_use_folder_perms"] = False

--- a/tests/yamlparser/fixtures/auth-jobs/project-in-folder-with-auth-properties2.xml
+++ b/tests/yamlparser/fixtures/auth-jobs/project-in-folder-with-auth-properties2.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<project>
+  <actions/>
+  <description>&lt;!-- Managed by Jenkins Job Builder --&gt;</description>
+  <keepDependencies>false</keepDependencies>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <concurrentBuild>false</concurrentBuild>
+  <canRoam>true</canRoam>
+  <properties>
+    <hudson.security.AuthorizationMatrixProperty>
+      <inheritanceStrategy class="org.jenkinsci.plugins.matrixauth.inheritance.InheritParentStrategy"/>
+      <permission>hudson.model.Item.Build:auser</permission>
+    </hudson.security.AuthorizationMatrixProperty>
+  </properties>
+  <scm class="hudson.scm.NullSCM"/>
+  <builders/>
+  <publishers/>
+  <buildWrappers/>
+</project>

--- a/tests/yamlparser/fixtures/project-in-folder-with-auth-properties2.yaml
+++ b/tests/yamlparser/fixtures/project-in-folder-with-auth-properties2.yaml
@@ -1,0 +1,7 @@
+- job:
+    name: auth-jobs/auth-job-test
+    project-type: freestyle
+    properties:
+    - authorization:
+        auser:
+          - job-build


### PR DESCRIPTION
When a job is stored in a folder and the JJB definition file uses "name"
key to specify the full path, folder + the actual name of the job, the
authorization matrix property is missing <inheritanceStrategy> tag in
the output XML.

This fix is an extension of a fix I made here:
- https://github.com/romanek-adam/jenkins-job-builder/commit/074985c7ff9360bb58be80ffab686746267f814f

Instead of just checking for "folder" key we now also check for a folder
separator in the "name" key to determine if a given job is stored in a
folder. This way we support both cases and generate the missing
<inheritanceStrategy> tag.

The copyright reflects this and the previous contribution in this
module.

Change-Id: I84b22c09c8a107aab2b4eca20feffc9b61675a92