### PR TITLE
Fixed archive-output-xml on Robot Publisher Plugin

### DIFF
--- a/jenkins_jobs/modules/publishers.py
+++ b/jenkins_jobs/modules/publishers.py
@@ -4607,7 +4607,7 @@ def robot(registry, xml_parent, data):
         checking the thresholds (default true)
     :arg list other-files: list other files to archive (default '')
     :arg bool archive-output-xml: Archive output xml file to server
-        (default true)
+        (default false)
     :arg bool enable-cache: Enable cache for test results (default true)
 
     Minimal Example:
@@ -4639,7 +4639,7 @@ def robot(registry, xml_parent, data):
     for other_file in data.get("other-files", []):
         XML.SubElement(other_files, "string").text = str(other_file)
     XML.SubElement(parent, "disableArchiveOutput").text = str(
-        not data.get("archive-output-xml", True)
+        data.get("archive-output-xml", False)
     ).lower()
 
 

--- a/tests/publishers/fixtures/robot-full.xml
+++ b/tests/publishers/fixtures/robot-full.xml
@@ -15,7 +15,7 @@
         <string>extra-file1.html</string>
         <string>extra-file2.txt</string>
       </otherFiles>
-      <disableArchiveOutput>true</disableArchiveOutput>
+      <disableArchiveOutput>false</disableArchiveOutput>
     </hudson.plugins.robot.RobotPublisher>
   </publishers>
 </project>


### PR DESCRIPTION
The default was supposed to be False and the current implementation
was giving wrong result. Fixed the problem and updated the test
case.

Signed-off-by: Eren ATAS <eatas.contractor@libertyglobal.com>