### PR TITLE
Fix Authorization Matrix property support on jobs outside a folder

### DIFF
--- a/jenkins_jobs/modules/properties.py
+++ b/jenkins_jobs/modules/properties.py
@@ -519,9 +519,6 @@ def authorization(registry, xml_parent, data):
        :language: yaml
     """
 
-    # get the folder name if it exists
-    in_a_folder = data.pop("_use_folder_perms", None) if data else None
-
     # check if it's a folder or a job
     is_a_folder = data.pop("_is_a_folder", None) if data else False
 
@@ -552,23 +549,18 @@ def authorization(registry, xml_parent, data):
     }
 
     if data:
-        if in_a_folder:
-            if is_a_folder:
-                element_name = "com.cloudbees.hudson.plugins.folder.properties.AuthorizationMatrixProperty"
-            else:
-                element_name = "hudson.security.AuthorizationMatrixProperty"
-            matrix = XML.SubElement(xml_parent, element_name)
-            XML.SubElement(
-                matrix,
-                "inheritanceStrategy",
-                {
-                    "class": "org.jenkinsci.plugins.matrixauth.inheritance.InheritParentStrategy"
-                },
-            )
+        if is_a_folder:
+            element_name = "com.cloudbees.hudson.plugins.folder.properties.AuthorizationMatrixProperty"
         else:
-            matrix = XML.SubElement(
-                xml_parent, "hudson.security.AuthorizationMatrixProperty"
-            )
+            element_name = "hudson.security.AuthorizationMatrixProperty"
+        matrix = XML.SubElement(xml_parent, element_name)
+        XML.SubElement(
+            matrix,
+            "inheritanceStrategy",
+            {
+                "class": "org.jenkinsci.plugins.matrixauth.inheritance.InheritParentStrategy"
+            },
+        )
 
         for (username, perms) in data.items():
             for perm in perms:
@@ -1272,16 +1264,10 @@ class Properties(jenkins_jobs.modules.base.Base):
                 # Only projects are placed in folders
                 if "project-type" in data:
                     if data["project-type"] in ("folder", "multibranch"):
-                        prop["authorization"]["_use_folder_perms"] = True
                         prop["authorization"]["_is_a_folder"] = True
                     else:
-                        job_in_folder = ("folder" in data) or (
-                            "/" in data.get("name", "")
-                        )
-                        prop["authorization"]["_use_folder_perms"] = job_in_folder
                         prop["authorization"]["_is_a_folder"] = False
                 else:
-                    prop["authorization"]["_use_folder_perms"] = False
                     prop["authorization"]["_is_a_folder"] = False
 
             self.registry.dispatch("property", properties, prop)

--- a/tests/properties/fixtures/authorization.xml
+++ b/tests/properties/fixtures/authorization.xml
@@ -2,6 +2,7 @@
 <project>
   <properties>
     <hudson.security.AuthorizationMatrixProperty>
+      <inheritanceStrategy class="org.jenkinsci.plugins.matrixauth.inheritance.InheritParentStrategy"/>
       <permission>com.cloudbees.plugins.credentials.CredentialsProvider.Create:admin</permission>
       <permission>com.cloudbees.plugins.credentials.CredentialsProvider.Delete:admin</permission>
       <permission>com.cloudbees.plugins.credentials.CredentialsProvider.ManageDomains:admin</permission>

--- a/tests/properties/fixtures/authorization_matrix.xml
+++ b/tests/properties/fixtures/authorization_matrix.xml
@@ -2,6 +2,7 @@
 <project>
   <properties>
     <hudson.security.AuthorizationMatrixProperty>
+      <inheritanceStrategy class="org.jenkinsci.plugins.matrixauth.inheritance.InheritParentStrategy"/>
       <permission>hudson.model.Item.Delete:admin</permission>
       <permission>hudson.model.Item.Configure:admin</permission>
       <permission>hudson.model.Item.Read:admin</permission>

--- a/tests/yamlparser/fixtures/project-with-auth-properties.xml
+++ b/tests/yamlparser/fixtures/project-with-auth-properties.xml
@@ -14,6 +14,7 @@
   <canRoam>true</canRoam>
   <properties>
     <hudson.security.AuthorizationMatrixProperty>
+      <inheritanceStrategy class="org.jenkinsci.plugins.matrixauth.inheritance.InheritParentStrategy"/>
       <permission>hudson.model.Item.Build:auser</permission>
     </hudson.security.AuthorizationMatrixProperty>
   </properties>


### PR DESCRIPTION
Up until now <inheritanceStrategy> tag was only added to jobs-in-a-folder
and folder configs. In JJB the tag's class is always set to
"InheritParentStrategy" which according to the docs means the "item will
inherit its parent items permissions". Apparently <inheritanceStrategy>
tag needs to be present on top-level jobs also. For top-level jobs
setting the tag's class value to "InheritParentStrategy" means the job
"will inherit the global security security settings" and this is the
default behavior.

The code has simplified a bit - if it's a folder then we use a different
property name for authorization matrix property, other than that the
code is the same for all three "variants": folder, job-in-a-folder and
job-outside-a-folder.