### PR TITLE
Added property-multiline for parameterized build trigger plugin

### DIFF
--- a/jenkins_jobs/modules/helpers.py
+++ b/jenkins_jobs/modules/helpers.py
@@ -13,12 +13,15 @@
 # under the License.
 
 import logging
+import sys
 
 import xml.etree.ElementTree as XML
 
 from jenkins_jobs.errors import InvalidAttributeError
 from jenkins_jobs.errors import JenkinsJobsException
 from jenkins_jobs.errors import MissingAttributeError
+
+import pkg_resources
 
 
 def build_trends_publisher(plugin_name, xml_element, data):
@@ -510,7 +513,10 @@ def trigger_get_parameter_order(registry, plugin):
     return None
 
 
-def trigger_project(tconfigs, project_def, param_order=None):
+def trigger_project(tconfigs, project_def, registry, param_order=None):
+
+    info = registry.get_plugin_info("parameterized-trigger")
+    plugin_version = pkg_resources.parse_version(info.get("version", str(sys.maxsize)))
 
     logger = logging.getLogger("%s:trigger_project" % __name__)
     pt_prefix = "hudson.plugins.parameterizedtrigger."
@@ -547,6 +553,12 @@ def trigger_project(tconfigs, project_def, param_order=None):
                 ("property-file", "propertiesFile", None),
                 ("fail-on-missing", "failTriggerOnMissing", False),
             ]
+
+            if plugin_version >= pkg_resources.parse_version("2.35.2"):
+                property_file_mapping.append(
+                    ("property-multiline", "textParamValueOnNewLine", False)
+                )
+
             convert_mapping_to_xml(
                 params, project_def, property_file_mapping, fail_required=True
             )

--- a/jenkins_jobs/modules/publishers.py
+++ b/jenkins_jobs/modules/publishers.py
@@ -527,6 +527,12 @@ def trigger_parameterized_builds(registry, xml_parent, data):
         if any of the property files are not found in the workspace.
         Only valid when 'property-file' is specified.
         (default 'False')
+    :arg bool property-multiline: When enabled properties containing
+        newline character(s) are propagated as TextParameterValue which is
+        a specialized StringParameterValue commonly used for handling
+        multi-line strings in Jenkins. When disabled (default)
+        all properties are propagated as StringParameterValue. (default
+        'False') (>=2.35.2)
     :arg bool trigger-from-child-projects: Trigger build from child projects.
         Used for matrix projects. (default 'False')
     :arg bool use-matrix-child-files: Use files in workspaces of child
@@ -568,7 +574,7 @@ def trigger_parameterized_builds(registry, xml_parent, data):
         tconfig = XML.SubElement(configs, pt_prefix + "BuildTriggerConfig")
         tconfigs = XML.SubElement(tconfig, "configs")
 
-        helpers.trigger_project(tconfigs, project_def, param_order)
+        helpers.trigger_project(tconfigs, project_def, registry, param_order)
 
         if not list(tconfigs):
             # no child parameter tags added
@@ -2395,7 +2401,7 @@ def pipeline(registry, xml_parent, data):
 
         configs = XML.SubElement(pippub, "configs")
 
-        helpers.trigger_project(configs, data, param_order)
+        helpers.trigger_project(configs, data, registry, param_order)
 
         XML.SubElement(pippub, "downstreamProjectNames").text = projects
 

--- a/tests/publishers/fixtures/pipeline003.plugins_info.yaml
+++ b/tests/publishers/fixtures/pipeline003.plugins_info.yaml
@@ -1,0 +1,3 @@
+- longName: 'Parameterized Trigger'
+  shortName: 'parameterized-trigger'
+  version: "2.34"

--- a/tests/publishers/fixtures/trigger_parameterized_builds/parameter-override-ordering.xml
+++ b/tests/publishers/fixtures/trigger_parameterized_builds/parameter-override-ordering.xml
@@ -11,6 +11,7 @@
             <hudson.plugins.parameterizedtrigger.FileBuildParameters>
               <propertiesFile>version.prop</propertiesFile>
               <failTriggerOnMissing>false</failTriggerOnMissing>
+              <textParamValueOnNewLine>false</textParamValueOnNewLine>
             </hudson.plugins.parameterizedtrigger.FileBuildParameters>
             <hudson.plugins.parameterizedtrigger.CurrentBuildParameters/>
           </configs>
@@ -28,6 +29,7 @@
             <hudson.plugins.parameterizedtrigger.FileBuildParameters>
               <propertiesFile>version.prop</propertiesFile>
               <failTriggerOnMissing>false</failTriggerOnMissing>
+              <textParamValueOnNewLine>false</textParamValueOnNewLine>
             </hudson.plugins.parameterizedtrigger.FileBuildParameters>
           </configs>
           <projects>yet_another_job</projects>

--- a/tests/publishers/fixtures/trigger_parameterized_builds001.xml
+++ b/tests/publishers/fixtures/trigger_parameterized_builds001.xml
@@ -27,6 +27,7 @@ bar=foo
             <hudson.plugins.parameterizedtrigger.FileBuildParameters>
               <propertiesFile>version.prop</propertiesFile>
               <failTriggerOnMissing>true</failTriggerOnMissing>
+              <textParamValueOnNewLine>true</textParamValueOnNewLine>
             </hudson.plugins.parameterizedtrigger.FileBuildParameters>
           </configs>
           <projects>other_job1, other_job2</projects>

--- a/tests/publishers/fixtures/trigger_parameterized_builds001.yaml
+++ b/tests/publishers/fixtures/trigger_parameterized_builds001.yaml
@@ -12,6 +12,7 @@ publishers:
       git-revision: true
       property-file: version.prop
       fail-on-missing: true
+      property-multiline: true
     - project: yet_another_job
       predefined-parameters: foo=bar
       git-revision:

--- a/tests/publishers/fixtures/trigger_parameterized_builds003.plugins_info.yaml
+++ b/tests/publishers/fixtures/trigger_parameterized_builds003.plugins_info.yaml
@@ -1,0 +1,3 @@
+- longName: 'Parameterized Trigger'
+  shortName: 'parameterized-trigger'
+  version: "2.34"

--- a/tests/publishers/fixtures/trigger_parameterized_builds004.plugins_info.yaml
+++ b/tests/publishers/fixtures/trigger_parameterized_builds004.plugins_info.yaml
@@ -1,0 +1,3 @@
+- longName: 'Parameterized Trigger'
+  shortName: 'parameterized-trigger'
+  version: "2.34"

--- a/tests/publishers/fixtures/trigger_parameterized_builds005.xml
+++ b/tests/publishers/fixtures/trigger_parameterized_builds005.xml
@@ -8,6 +8,7 @@
             <hudson.plugins.parameterizedtrigger.FileBuildParameters>
               <propertiesFile>version.prop</propertiesFile>
               <failTriggerOnMissing>false</failTriggerOnMissing>
+              <textParamValueOnNewLine>false</textParamValueOnNewLine>
               <useMatrixChild>true</useMatrixChild>
               <combinationFilter>FOO &amp;&amp; BAR</combinationFilter>
               <onlyExactRuns>true</onlyExactRuns>

--- a/tests/yamlparser/fixtures/trigger_parameterized_builds/parameter-override-ordering-001.plugins_info.yaml
+++ b/tests/yamlparser/fixtures/trigger_parameterized_builds/parameter-override-ordering-001.plugins_info.yaml
@@ -1,0 +1,3 @@
+- longName: 'Parameterized Trigger'
+  shortName: 'parameterized-trigger'
+  version: "2.34"

--- a/tests/yamlparser/fixtures/trigger_parameterized_builds/parameter-override-ordering-002.plugins_info.yaml
+++ b/tests/yamlparser/fixtures/trigger_parameterized_builds/parameter-override-ordering-002.plugins_info.yaml
@@ -1,0 +1,3 @@
+- longName: 'Parameterized Trigger'
+  shortName: 'parameterized-trigger'
+  version: "2.34"

--- a/tests/yamlparser/fixtures/trigger_parameterized_builds/parameter-override-ordering-003.plugins_info.yaml
+++ b/tests/yamlparser/fixtures/trigger_parameterized_builds/parameter-override-ordering-003.plugins_info.yaml
@@ -1,0 +1,3 @@
+- longName: 'Parameterized Trigger'
+  shortName: 'parameterized-trigger'
+  version: "2.34"


### PR DESCRIPTION
Updated test cases as well, The tag has been introduced after `2.35.2`
therefore the parameter is also `>=2.35.2`

Signed-off-by: Eren ATAS <eatas.contractor@libertyglobal.com>