### PR TITLE
Fixed docs-linkcheck

### DIFF
--- a/jenkins_jobs/modules/triggers.py
+++ b/jenkins_jobs/modules/triggers.py
@@ -569,9 +569,9 @@ def gerrit(registry, xml_parent, data):
 
         .. deprecated:: 3.5.0  Supported for Gerrit Trigger Plugin versions
             < 2.14.0. See
-            `Missed Events Playback Feature <https://plugins.jenkins.io/
-            gerrit-trigger#missed-events-playback-feature-available-from-
-            v-2-14-0>`_.
+            `Missed Events Playback Feature <https://github.com/jenkinsci/
+            gerrit-trigger-plugin/blob/master/docs/README.adoc#user-content
+            -missed-events-playback-feature-available-from-v-2140>`_.
 
     :arg str custom-url: Custom URL for a message sent to Gerrit. Build
         details URL will be used if empty. (default '')


### PR DESCRIPTION
The documentation for Gerrit Trigger plugin changed on Jenkins
Plugins page to Github. The link that broke the `docs-linkcheck`
have been changed to fix the problem.

Signed-off-by: Eren ATAS <eatas.contractor@libertyglobal.com>
Co-authored-by: Adam Romanek <aromanek.contractor@libertyglobal.com>