### PR TITLE
Updated BuildTimeoutWrapper plugin

### DIFF
--- a/tests/wrappers/fixtures/timeout/version-1.17/timeout004.plugins_info.yaml
+++ b/tests/wrappers/fixtures/timeout/version-1.17/timeout004.plugins_info.yaml
@@ -1,0 +1,3 @@
+- longName: 'Jenkins build timeout plugin'
+  shortName: 'build-timeout'
+  version: "1.17"

--- a/tests/wrappers/fixtures/timeout/version-1.17/timeout004.xml
+++ b/tests/wrappers/fixtures/timeout/version-1.17/timeout004.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<project>
+  <buildWrappers>
+    <hudson.plugins.build__timeout.BuildTimeoutWrapper>
+      <strategy class="hudson.plugins.build_timeout.impl.AbsoluteTimeOutStrategy">
+        <timeoutMinutes>40</timeoutMinutes>
+      </strategy>
+      <operationList>
+        <hudson.plugins.build__timeout.operations.AbortAndRestartOperation>
+          <maxRestarts>2</maxRestarts>
+        </hudson.plugins.build__timeout.operations.AbortAndRestartOperation>
+      </operationList>
+    </hudson.plugins.build__timeout.BuildTimeoutWrapper>
+  </buildWrappers>
+</project>

--- a/tests/wrappers/fixtures/timeout/version-1.17/timeout004.yaml
+++ b/tests/wrappers/fixtures/timeout/version-1.17/timeout004.yaml
@@ -1,0 +1,6 @@
+wrappers:
+  - timeout:
+      abort-and-restart: true
+      max-restarts: 2
+      timeout: 40
+      type: absolute


### PR DESCRIPTION
On version 1.17 of `BuildTimeoutWrapper` plugin, new option
called `AbortAndRestart` has been introduced. The plugin support
has been updated in order to support this option. A test case
also added.

Signed-off-by: Eren ATAS <eatas.contractor@libertyglobal.com>