### PR TITLE
Updated Email Extended Publisher Plugin

### DIFF
--- a/jenkins_jobs/modules/publishers.py
+++ b/jenkins_jobs/modules/publishers.py
@@ -2576,9 +2576,13 @@ def base_email_ext(registry, xml_parent, data, ttype):
         XML.SubElement(trigger, "triggerScript").text = data["trigger-script"]
 
     if plugin_version >= pkg_resources.parse_version("2.39"):
-        XML.SubElement(email, "attachmentsPattern").text = ""
-        XML.SubElement(email, "attachBuildLog").text = "false"
-        XML.SubElement(email, "compressBuildLog").text = "false"
+        mappings = [
+            ("attachments", "attachmentsPattern", ""),
+            ("attach-build-log", "attachBuildLog", False),
+            ("compress-log", "compressBuildLog", False),
+        ]
+
+        helpers.convert_mapping_to_xml(email, data, mappings, fail_required=True)
 
 
 def email_ext(registry, xml_parent, data):

--- a/tests/publishers/fixtures/email-ext004.xml
+++ b/tests/publishers/fixtures/email-ext004.xml
@@ -19,9 +19,9 @@
               <hudson.plugins.emailext.plugins.recipients.FirstFailingBuildSuspectsRecipientProvider/>
               <hudson.plugins.emailext.plugins.recipients.UpstreamComitterRecipientProvider/>
             </recipientProviders>
-            <attachmentsPattern/>
-            <attachBuildLog>false</attachBuildLog>
-            <compressBuildLog>false</compressBuildLog>
+            <attachmentsPattern>*/foo*.log</attachmentsPattern>
+            <attachBuildLog>true</attachBuildLog>
+            <compressBuildLog>true</compressBuildLog>
           </email>
         </hudson.plugins.emailext.plugins.trigger.AlwaysTrigger>
         <hudson.plugins.emailext.plugins.trigger.UnstableTrigger>
@@ -39,9 +39,9 @@
               <hudson.plugins.emailext.plugins.recipients.FirstFailingBuildSuspectsRecipientProvider/>
               <hudson.plugins.emailext.plugins.recipients.UpstreamComitterRecipientProvider/>
             </recipientProviders>
-            <attachmentsPattern/>
-            <attachBuildLog>false</attachBuildLog>
-            <compressBuildLog>false</compressBuildLog>
+            <attachmentsPattern>*/foo*.log</attachmentsPattern>
+            <attachBuildLog>true</attachBuildLog>
+            <compressBuildLog>true</compressBuildLog>
           </email>
         </hudson.plugins.emailext.plugins.trigger.UnstableTrigger>
         <hudson.plugins.emailext.plugins.trigger.FirstFailureTrigger>
@@ -59,9 +59,9 @@
               <hudson.plugins.emailext.plugins.recipients.FirstFailingBuildSuspectsRecipientProvider/>
               <hudson.plugins.emailext.plugins.recipients.UpstreamComitterRecipientProvider/>
             </recipientProviders>
-            <attachmentsPattern/>
-            <attachBuildLog>false</attachBuildLog>
-            <compressBuildLog>false</compressBuildLog>
+            <attachmentsPattern>*/foo*.log</attachmentsPattern>
+            <attachBuildLog>true</attachBuildLog>
+            <compressBuildLog>true</compressBuildLog>
           </email>
           <failureCount>0</failureCount>
         </hudson.plugins.emailext.plugins.trigger.FirstFailureTrigger>
@@ -80,9 +80,9 @@
               <hudson.plugins.emailext.plugins.recipients.FirstFailingBuildSuspectsRecipientProvider/>
               <hudson.plugins.emailext.plugins.recipients.UpstreamComitterRecipientProvider/>
             </recipientProviders>
-            <attachmentsPattern/>
-            <attachBuildLog>false</attachBuildLog>
-            <compressBuildLog>false</compressBuildLog>
+            <attachmentsPattern>*/foo*.log</attachmentsPattern>
+            <attachBuildLog>true</attachBuildLog>
+            <compressBuildLog>true</compressBuildLog>
           </email>
         </hudson.plugins.emailext.plugins.trigger.FirstUnstableTrigger>
         <hudson.plugins.emailext.plugins.trigger.NotBuiltTrigger>
@@ -100,9 +100,9 @@
               <hudson.plugins.emailext.plugins.recipients.FirstFailingBuildSuspectsRecipientProvider/>
               <hudson.plugins.emailext.plugins.recipients.UpstreamComitterRecipientProvider/>
             </recipientProviders>
-            <attachmentsPattern/>
-            <attachBuildLog>false</attachBuildLog>
-            <compressBuildLog>false</compressBuildLog>
+            <attachmentsPattern>*/foo*.log</attachmentsPattern>
+            <attachBuildLog>true</attachBuildLog>
+            <compressBuildLog>true</compressBuildLog>
           </email>
         </hudson.plugins.emailext.plugins.trigger.NotBuiltTrigger>
         <hudson.plugins.emailext.plugins.trigger.AbortedTrigger>
@@ -120,9 +120,9 @@
               <hudson.plugins.emailext.plugins.recipients.FirstFailingBuildSuspectsRecipientProvider/>
               <hudson.plugins.emailext.plugins.recipients.UpstreamComitterRecipientProvider/>
             </recipientProviders>
-            <attachmentsPattern/>
-            <attachBuildLog>false</attachBuildLog>
-            <compressBuildLog>false</compressBuildLog>
+            <attachmentsPattern>*/foo*.log</attachmentsPattern>
+            <attachBuildLog>true</attachBuildLog>
+            <compressBuildLog>true</compressBuildLog>
           </email>
         </hudson.plugins.emailext.plugins.trigger.AbortedTrigger>
         <hudson.plugins.emailext.plugins.trigger.RegressionTrigger>
@@ -140,9 +140,9 @@
               <hudson.plugins.emailext.plugins.recipients.FirstFailingBuildSuspectsRecipientProvider/>
               <hudson.plugins.emailext.plugins.recipients.UpstreamComitterRecipientProvider/>
             </recipientProviders>
-            <attachmentsPattern/>
-            <attachBuildLog>false</attachBuildLog>
-            <compressBuildLog>false</compressBuildLog>
+            <attachmentsPattern>*/foo*.log</attachmentsPattern>
+            <attachBuildLog>true</attachBuildLog>
+            <compressBuildLog>true</compressBuildLog>
           </email>
         </hudson.plugins.emailext.plugins.trigger.RegressionTrigger>
         <hudson.plugins.emailext.plugins.trigger.FailureTrigger>
@@ -160,9 +160,9 @@
               <hudson.plugins.emailext.plugins.recipients.FirstFailingBuildSuspectsRecipientProvider/>
               <hudson.plugins.emailext.plugins.recipients.UpstreamComitterRecipientProvider/>
             </recipientProviders>
-            <attachmentsPattern/>
-            <attachBuildLog>false</attachBuildLog>
-            <compressBuildLog>false</compressBuildLog>
+            <attachmentsPattern>*/foo*.log</attachmentsPattern>
+            <attachBuildLog>true</attachBuildLog>
+            <compressBuildLog>true</compressBuildLog>
           </email>
         </hudson.plugins.emailext.plugins.trigger.FailureTrigger>
         <hudson.plugins.emailext.plugins.trigger.SecondFailureTrigger>
@@ -180,9 +180,9 @@
               <hudson.plugins.emailext.plugins.recipients.FirstFailingBuildSuspectsRecipientProvider/>
               <hudson.plugins.emailext.plugins.recipients.UpstreamComitterRecipientProvider/>
             </recipientProviders>
-            <attachmentsPattern/>
-            <attachBuildLog>false</attachBuildLog>
-            <compressBuildLog>false</compressBuildLog>
+            <attachmentsPattern>*/foo*.log</attachmentsPattern>
+            <attachBuildLog>true</attachBuildLog>
+            <compressBuildLog>true</compressBuildLog>
           </email>
           <failureCount>0</failureCount>
         </hudson.plugins.emailext.plugins.trigger.SecondFailureTrigger>
@@ -201,9 +201,9 @@
               <hudson.plugins.emailext.plugins.recipients.FirstFailingBuildSuspectsRecipientProvider/>
               <hudson.plugins.emailext.plugins.recipients.UpstreamComitterRecipientProvider/>
             </recipientProviders>
-            <attachmentsPattern/>
-            <attachBuildLog>false</attachBuildLog>
-            <compressBuildLog>false</compressBuildLog>
+            <attachmentsPattern>*/foo*.log</attachmentsPattern>
+            <attachBuildLog>true</attachBuildLog>
+            <compressBuildLog>true</compressBuildLog>
           </email>
         </hudson.plugins.emailext.plugins.trigger.ImprovementTrigger>
         <hudson.plugins.emailext.plugins.trigger.StillFailingTrigger>
@@ -221,9 +221,9 @@
               <hudson.plugins.emailext.plugins.recipients.FirstFailingBuildSuspectsRecipientProvider/>
               <hudson.plugins.emailext.plugins.recipients.UpstreamComitterRecipientProvider/>
             </recipientProviders>
-            <attachmentsPattern/>
-            <attachBuildLog>false</attachBuildLog>
-            <compressBuildLog>false</compressBuildLog>
+            <attachmentsPattern>*/foo*.log</attachmentsPattern>
+            <attachBuildLog>true</attachBuildLog>
+            <compressBuildLog>true</compressBuildLog>
           </email>
         </hudson.plugins.emailext.plugins.trigger.StillFailingTrigger>
         <hudson.plugins.emailext.plugins.trigger.SuccessTrigger>
@@ -241,9 +241,9 @@
               <hudson.plugins.emailext.plugins.recipients.FirstFailingBuildSuspectsRecipientProvider/>
               <hudson.plugins.emailext.plugins.recipients.UpstreamComitterRecipientProvider/>
             </recipientProviders>
-            <attachmentsPattern/>
-            <attachBuildLog>false</attachBuildLog>
-            <compressBuildLog>false</compressBuildLog>
+            <attachmentsPattern>*/foo*.log</attachmentsPattern>
+            <attachBuildLog>true</attachBuildLog>
+            <compressBuildLog>true</compressBuildLog>
           </email>
         </hudson.plugins.emailext.plugins.trigger.SuccessTrigger>
         <hudson.plugins.emailext.plugins.trigger.FixedTrigger>
@@ -261,9 +261,9 @@
               <hudson.plugins.emailext.plugins.recipients.FirstFailingBuildSuspectsRecipientProvider/>
               <hudson.plugins.emailext.plugins.recipients.UpstreamComitterRecipientProvider/>
             </recipientProviders>
-            <attachmentsPattern/>
-            <attachBuildLog>false</attachBuildLog>
-            <compressBuildLog>false</compressBuildLog>
+            <attachmentsPattern>*/foo*.log</attachmentsPattern>
+            <attachBuildLog>true</attachBuildLog>
+            <compressBuildLog>true</compressBuildLog>
           </email>
         </hudson.plugins.emailext.plugins.trigger.FixedTrigger>
         <hudson.plugins.emailext.plugins.trigger.FixedUnhealthyTrigger>
@@ -281,9 +281,9 @@
               <hudson.plugins.emailext.plugins.recipients.FirstFailingBuildSuspectsRecipientProvider/>
               <hudson.plugins.emailext.plugins.recipients.UpstreamComitterRecipientProvider/>
             </recipientProviders>
-            <attachmentsPattern/>
-            <attachBuildLog>false</attachBuildLog>
-            <compressBuildLog>false</compressBuildLog>
+            <attachmentsPattern>*/foo*.log</attachmentsPattern>
+            <attachBuildLog>true</attachBuildLog>
+            <compressBuildLog>true</compressBuildLog>
           </email>
         </hudson.plugins.emailext.plugins.trigger.FixedUnhealthyTrigger>
         <hudson.plugins.emailext.plugins.trigger.StillUnstableTrigger>
@@ -301,9 +301,9 @@
               <hudson.plugins.emailext.plugins.recipients.FirstFailingBuildSuspectsRecipientProvider/>
               <hudson.plugins.emailext.plugins.recipients.UpstreamComitterRecipientProvider/>
             </recipientProviders>
-            <attachmentsPattern/>
-            <attachBuildLog>false</attachBuildLog>
-            <compressBuildLog>false</compressBuildLog>
+            <attachmentsPattern>*/foo*.log</attachmentsPattern>
+            <attachBuildLog>true</attachBuildLog>
+            <compressBuildLog>true</compressBuildLog>
           </email>
         </hudson.plugins.emailext.plugins.trigger.StillUnstableTrigger>
         <hudson.plugins.emailext.plugins.trigger.PreBuildTrigger>
@@ -321,9 +321,9 @@
               <hudson.plugins.emailext.plugins.recipients.FirstFailingBuildSuspectsRecipientProvider/>
               <hudson.plugins.emailext.plugins.recipients.UpstreamComitterRecipientProvider/>
             </recipientProviders>
-            <attachmentsPattern/>
-            <attachBuildLog>false</attachBuildLog>
-            <compressBuildLog>false</compressBuildLog>
+            <attachmentsPattern>*/foo*.log</attachmentsPattern>
+            <attachBuildLog>true</attachBuildLog>
+            <compressBuildLog>true</compressBuildLog>
           </email>
         </hudson.plugins.emailext.plugins.trigger.PreBuildTrigger>
       </configuredTriggers>
@@ -333,8 +333,8 @@
       <attachmentsPattern>*/foo*.log</attachmentsPattern>
       <presendScript>cancel=true</presendScript>
       <postsendScript>cancel=true</postsendScript>
-      <attachBuildLog>false</attachBuildLog>
-      <compressBuildLog>false</compressBuildLog>
+      <attachBuildLog>true</attachBuildLog>
+      <compressBuildLog>true</compressBuildLog>
       <saveOutput>true</saveOutput>
       <disabled>false</disabled>
       <replyTo>foo@example.com</replyTo>

--- a/tests/publishers/fixtures/email-ext004.yaml
+++ b/tests/publishers/fixtures/email-ext004.yaml
@@ -6,8 +6,8 @@ publishers:
       content-type: html
       subject: Subject for Build ${BUILD_NUMBER}
       body: The build has finished
-      attach-build-log: false
-      compress-log: false
+      attach-build-log: true
+      compress-log: true
       attachments: "*/foo*.log"
       always: true
       unstable: true

--- a/tests/publishers/fixtures/email-ext005.xml
+++ b/tests/publishers/fixtures/email-ext005.xml
@@ -13,7 +13,7 @@
             <recipientProviders>
               <hudson.plugins.emailext.plugins.recipients.ListRecipientProvider/>
             </recipientProviders>
-            <attachmentsPattern/>
+            <attachmentsPattern>*/foo*.log</attachmentsPattern>
             <attachBuildLog>false</attachBuildLog>
             <compressBuildLog>false</compressBuildLog>
           </email>
@@ -27,7 +27,7 @@
             <recipientProviders>
               <hudson.plugins.emailext.plugins.recipients.ListRecipientProvider/>
             </recipientProviders>
-            <attachmentsPattern/>
+            <attachmentsPattern>*/foo*.log</attachmentsPattern>
             <attachBuildLog>false</attachBuildLog>
             <compressBuildLog>false</compressBuildLog>
           </email>
@@ -41,7 +41,7 @@
             <recipientProviders>
               <hudson.plugins.emailext.plugins.recipients.ListRecipientProvider/>
             </recipientProviders>
-            <attachmentsPattern/>
+            <attachmentsPattern>*/foo*.log</attachmentsPattern>
             <attachBuildLog>false</attachBuildLog>
             <compressBuildLog>false</compressBuildLog>
           </email>


### PR DESCRIPTION
Parameters inside triggers were not updated while the upper
parameters were changed, were staying as default. Updated
the implementation to make it take from the upper level.

Signed-off-by: Eren ATAS <eatas.contractor@libertyglobal.com>