### PR TITLE
[ONEM-18289] Adjust 'stevedore' version for Python 3.5 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,8 @@
 six>=1.9.0 # MIT
 PyYAML>=3.10.0,<6 # MIT
 pbr>=1.8 # Apache-2.0
-stevedore>=1.17.1 # Apache-2.0
+stevedore>=1.17.1,<3.0.0;python_version=='3.5' # Apache-2.0
+stevedore>=1.17.1;python_version>='3.6' # Apache-2.0
 python-jenkins>=0.4.15
 fasteners
 Jinja2


### PR DESCRIPTION
Checked with Python 3.5, installed stevedore-2.0.1.
Checked with Python 3.7, installed stevedore-3.2.2.