### PR TITLE
[ONEM-18978] Update Gerrit Trigger Plugin Implementation

### DIFF
--- a/tests/jsonparser/fixtures/complete001.json
+++ b/tests/jsonparser/fixtures/complete001.json
@@ -74,6 +74,11 @@
             "trigger-on-ref-updated-event": false,
             "trigger-on-comment-added-event": false,
             "override-votes": true,
+            "build-cancellation-policy": {
+                "abort-new-patchsets": true,
+                "abort-manual-patchsets": false,
+                "abort-same-topic": true
+            },
             "gerrit-build-started-verified-value": 0,
             "gerrit-build-successful-verified-value": 1,
             "gerrit-build-failed-verified-value": -1,
@@ -84,6 +89,8 @@
             "gerrit-build-failed-codereview-value": -1,
             "gerrit-build-unstable-codereview-value": -1,
             "gerrit-build-notbuilt-codereview-value": -1,
+            "gerrit-build-aborted-verified-value": 0,
+            "gerrit-build-aborted-codereview-value": 0,
             "projects": [
               {
                 "project-compare-type": "PLAIN",
@@ -100,7 +107,8 @@
             "failure-message": "Failed message.",
             "successful-message": "Success message.",
             "unstable-message": "Unstable message.",
-            "notbuilt-message": "Not built message."
+            "notbuilt-message": "Not built message.",
+            "aborted-message": "Aborted message."
           }
         }
       ]

--- a/tests/jsonparser/fixtures/complete001.xml
+++ b/tests/jsonparser/fixtures/complete001.xml
@@ -64,7 +64,14 @@
         <onFailed>false</onFailed>
         <onUnstable>false</onUnstable>
         <onNotBuilt>false</onNotBuilt>
+        <onAborted>false</onAborted>
       </skipVote>
+      <buildCancellationPolicy>
+        <enabled>true</enabled>
+        <abortNewPatchsets>true</abortNewPatchsets>
+        <abortManualPatchsets>false</abortManualPatchsets>
+        <abortSameTopic>true</abortSameTopic>
+      </buildCancellationPolicy>
       <silentMode>false</silentMode>
       <silentStartMode>false</silentStartMode>
       <escapeQuotes>true</escapeQuotes>
@@ -91,6 +98,8 @@
       <gerritBuildFailedCodeReviewValue>-1</gerritBuildFailedCodeReviewValue>
       <gerritBuildUnstableCodeReviewValue>-1</gerritBuildUnstableCodeReviewValue>
       <gerritBuildNotBuiltCodeReviewValue>-1</gerritBuildNotBuiltCodeReviewValue>
+      <gerritBuildAbortedVerifiedValue>0</gerritBuildAbortedVerifiedValue>
+      <gerritBuildAbortedCodeReviewValue>0</gerritBuildAbortedCodeReviewValue>
       <buildStartMessage>Start message.</buildStartMessage>
       <buildFailureMessage>Failed message.</buildFailureMessage>
       <buildSuccessfulMessage>Success message.</buildSuccessfulMessage>
@@ -99,6 +108,7 @@
       <buildUnsuccessfulFilepath/>
       <customUrl/>
       <serverName>__ANY__</serverName>
+      <buildAbortedMessage>Aborted message.</buildAbortedMessage>
     </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.GerritTrigger>
   </triggers>
   <builders>

--- a/tests/triggers/fixtures/gerrit001.xml
+++ b/tests/triggers/fixtures/gerrit001.xml
@@ -27,6 +27,7 @@
         <onFailed>true</onFailed>
         <onUnstable>true</onUnstable>
         <onNotBuilt>true</onNotBuilt>
+        <onAborted>true</onAborted>
       </skipVote>
       <silentMode>false</silentMode>
       <silentStartMode>false</silentStartMode>
@@ -54,6 +55,7 @@
       <buildUnsuccessfulFilepath/>
       <customUrl/>
       <serverName>__ANY__</serverName>
+      <buildAbortedMessage/>
     </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.GerritTrigger>
   </triggers>
 </project>

--- a/tests/triggers/fixtures/gerrit001.yaml
+++ b/tests/triggers/fixtures/gerrit001.yaml
@@ -16,6 +16,7 @@ triggers:
           failed: true
           unstable: true
           notbuilt: true
+          aborted: true
       silent: false
       escape-quotes: false
       no-name-and-email: false

--- a/tests/triggers/fixtures/gerrit002.xml
+++ b/tests/triggers/fixtures/gerrit002.xml
@@ -31,6 +31,7 @@
         <onFailed>true</onFailed>
         <onUnstable>true</onUnstable>
         <onNotBuilt>true</onNotBuilt>
+        <onAborted>false</onAborted>
       </skipVote>
       <silentMode>false</silentMode>
       <silentStartMode>false</silentStartMode>
@@ -58,6 +59,7 @@
       <buildUnsuccessfulFilepath/>
       <customUrl/>
       <serverName>__ANY__</serverName>
+      <buildAbortedMessage/>
     </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.GerritTrigger>
   </triggers>
 </project>

--- a/tests/triggers/fixtures/gerrit003.xml
+++ b/tests/triggers/fixtures/gerrit003.xml
@@ -48,6 +48,7 @@
         <onFailed>true</onFailed>
         <onUnstable>true</onUnstable>
         <onNotBuilt>true</onNotBuilt>
+        <onAborted>true</onAborted>
       </skipVote>
       <silentMode>false</silentMode>
       <silentStartMode>false</silentStartMode>
@@ -75,6 +76,7 @@
       <buildUnsuccessfulFilepath/>
       <customUrl/>
       <serverName>__ANY__</serverName>
+      <buildAbortedMessage/>
     </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.GerritTrigger>
   </triggers>
 </project>

--- a/tests/triggers/fixtures/gerrit003.yaml
+++ b/tests/triggers/fixtures/gerrit003.yaml
@@ -26,6 +26,7 @@ triggers:
           failed: true
           unstable: true
           notbuilt: true
+          aborted: true
       silent: false
       escape-quotes: false
       no-name-and-email: false

--- a/tests/triggers/fixtures/gerrit004.xml
+++ b/tests/triggers/fixtures/gerrit004.xml
@@ -37,7 +37,14 @@
         <onFailed>true</onFailed>
         <onUnstable>true</onUnstable>
         <onNotBuilt>true</onNotBuilt>
+        <onAborted>true</onAborted>
       </skipVote>
+      <buildCancellationPolicy>
+        <enabled>true</enabled>
+        <abortNewPatchsets>false</abortNewPatchsets>
+        <abortManualPatchsets>true</abortManualPatchsets>
+        <abortSameTopic>true</abortSameTopic>
+      </buildCancellationPolicy>
       <silentMode>false</silentMode>
       <silentStartMode>true</silentStartMode>
       <escapeQuotes>false</escapeQuotes>
@@ -57,6 +64,7 @@
           <excludeNoCodeChange>true</excludeNoCodeChange>
           <excludePrivateState>true</excludePrivateState>
           <excludeWipState>true</excludeWipState>
+          <commitMessageContainsRegEx>regex</commitMessageContainsRegEx>
         </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginPatchsetCreatedEvent>
         <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginCommentAddedEvent>
           <verdictCategory>APRV</verdictCategory>
@@ -71,6 +79,7 @@
       <buildUnsuccessfulFilepath>path/to/filename</buildUnsuccessfulFilepath>
       <customUrl/>
       <serverName>my-server</serverName>
+      <buildAbortedMessage/>
     </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.GerritTrigger>
   </triggers>
 </project>

--- a/tests/triggers/fixtures/gerrit004.yaml
+++ b/tests/triggers/fixtures/gerrit004.yaml
@@ -7,6 +7,7 @@ triggers:
             exclude-no-code-change: true
             exclude-private: true
             exclude-wip: true
+            commit-message-contains-regex: "regex"
         - comment-added-event:
             approval-category: 'APRV'
             approval-value: 1
@@ -29,6 +30,11 @@ triggers:
           failed: true
           unstable: true
           notbuilt: true
+          aborted: true
+      build-cancellation-policy:
+        abort-new-patchsets: false
+        abort-manual-patchsets: true
+        abort-same-topic: true
       silent: false
       silent-start: true
       escape-quotes: false

--- a/tests/triggers/fixtures/gerrit005.xml
+++ b/tests/triggers/fixtures/gerrit005.xml
@@ -27,6 +27,7 @@
         <onFailed>false</onFailed>
         <onUnstable>false</onUnstable>
         <onNotBuilt>false</onNotBuilt>
+        <onAborted>false</onAborted>
       </skipVote>
       <silentMode>false</silentMode>
       <silentStartMode>false</silentStartMode>
@@ -56,6 +57,7 @@
       <buildUnsuccessfulFilepath/>
       <customUrl/>
       <serverName>__ANY__</serverName>
+      <buildAbortedMessage/>
     </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.GerritTrigger>
   </triggers>
 </project>

--- a/tests/triggers/fixtures/gerrit006.xml
+++ b/tests/triggers/fixtures/gerrit006.xml
@@ -27,6 +27,7 @@
         <onFailed>true</onFailed>
         <onUnstable>true</onUnstable>
         <onNotBuilt>true</onNotBuilt>
+        <onAborted>true</onAborted>
       </skipVote>
       <silentMode>false</silentMode>
       <silentStartMode>false</silentStartMode>
@@ -53,6 +54,7 @@
       <buildUnsuccessfulFilepath/>
       <customUrl/>
       <serverName>__ANY__</serverName>
+      <buildAbortedMessage/>
     </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.GerritTrigger>
   </triggers>
 </project>

--- a/tests/triggers/fixtures/gerrit006.yaml
+++ b/tests/triggers/fixtures/gerrit006.yaml
@@ -16,6 +16,7 @@ triggers:
           failed: true
           unstable: true
           notbuilt: true
+          aborted: true
       silent: false
       escape-quotes: false
       no-name-and-email: false

--- a/tests/triggers/fixtures/gerrit007.xml
+++ b/tests/triggers/fixtures/gerrit007.xml
@@ -37,6 +37,7 @@
         <onFailed>true</onFailed>
         <onUnstable>true</onUnstable>
         <onNotBuilt>true</onNotBuilt>
+        <onAborted>true</onAborted>
       </skipVote>
       <silentMode>false</silentMode>
       <silentStartMode>false</silentStartMode>
@@ -65,6 +66,7 @@
       <buildUnsuccessfulFilepath/>
       <customUrl/>
       <serverName>my-server</serverName>
+      <buildAbortedMessage/>
     </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.GerritTrigger>
   </triggers>
 </project>

--- a/tests/triggers/fixtures/gerrit007.yaml
+++ b/tests/triggers/fixtures/gerrit007.yaml
@@ -24,6 +24,7 @@ triggers:
           failed: true
           unstable: true
           notbuilt: true
+          aborted: true
       silent: false
       escape-quotes: false
       no-name-and-email: false

--- a/tests/triggers/fixtures/gerrit008.xml
+++ b/tests/triggers/fixtures/gerrit008.xml
@@ -43,6 +43,7 @@
         <onFailed>true</onFailed>
         <onUnstable>true</onUnstable>
         <onNotBuilt>true</onNotBuilt>
+        <onAborted>true</onAborted>
       </skipVote>
       <silentMode>false</silentMode>
       <silentStartMode>true</silentStartMode>
@@ -63,6 +64,7 @@
           <excludeNoCodeChange>true</excludeNoCodeChange>
           <excludePrivateState>true</excludePrivateState>
           <excludeWipState>true</excludeWipState>
+          <commitMessageContainsRegEx>regex</commitMessageContainsRegEx>
         </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginPatchsetCreatedEvent>
         <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginCommentAddedEvent>
           <verdictCategory>APRV</verdictCategory>
@@ -77,6 +79,7 @@
       <buildUnsuccessfulFilepath>path/to/filename</buildUnsuccessfulFilepath>
       <customUrl/>
       <serverName>my-server</serverName>
+      <buildAbortedMessage/>
     </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.GerritTrigger>
   </triggers>
 </project>

--- a/tests/triggers/fixtures/gerrit008.yaml
+++ b/tests/triggers/fixtures/gerrit008.yaml
@@ -7,6 +7,7 @@ triggers:
             exclude-no-code-change: true
             exclude-private: true
             exclude-wip: true
+            commit-message-contains-regex: regex
         - comment-added-event:
             approval-category: 'APRV'
             approval-value: 1
@@ -32,6 +33,7 @@ triggers:
           failed: true
           unstable: true
           notbuilt: true
+          aborted: true
       silent: false
       silent-start: true
       escape-quotes: false

--- a/tests/triggers/fixtures/gerrit009.xml
+++ b/tests/triggers/fixtures/gerrit009.xml
@@ -9,6 +9,7 @@
         <onFailed>false</onFailed>
         <onUnstable>false</onUnstable>
         <onNotBuilt>false</onNotBuilt>
+        <onAborted>false</onAborted>
       </skipVote>
       <silentMode>false</silentMode>
       <silentStartMode>false</silentStartMode>
@@ -37,6 +38,7 @@
       <buildUnsuccessfulFilepath/>
       <customUrl/>
       <serverName>__ANY__</serverName>
+      <buildAbortedMessage/>
     </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.GerritTrigger>
   </triggers>
 </project>

--- a/tests/triggers/fixtures/gerrit010.xml
+++ b/tests/triggers/fixtures/gerrit010.xml
@@ -27,6 +27,7 @@
         <onFailed>false</onFailed>
         <onUnstable>false</onUnstable>
         <onNotBuilt>false</onNotBuilt>
+        <onAborted>false</onAborted>
       </skipVote>
       <silentMode>false</silentMode>
       <silentStartMode>false</silentStartMode>
@@ -54,6 +55,7 @@
       <buildUnsuccessfulFilepath/>
       <customUrl/>
       <serverName>__ANY__</serverName>
+      <buildAbortedMessage/>
     </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.GerritTrigger>
   </triggers>
 </project>

--- a/tests/triggers/fixtures/gerrit011-name-and-email-parameter-mode-base64.xml
+++ b/tests/triggers/fixtures/gerrit011-name-and-email-parameter-mode-base64.xml
@@ -9,6 +9,7 @@
         <onFailed>false</onFailed>
         <onUnstable>false</onUnstable>
         <onNotBuilt>false</onNotBuilt>
+        <onAborted>false</onAborted>
       </skipVote>
       <silentMode>false</silentMode>
       <silentStartMode>false</silentStartMode>
@@ -32,6 +33,7 @@
       <buildUnsuccessfulFilepath/>
       <customUrl/>
       <serverName>__ANY__</serverName>
+      <buildAbortedMessage/>
     </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.GerritTrigger>
   </triggers>
 </project>

--- a/tests/triggers/fixtures/gerrit013-name-and-email-parameter-mode-plain.xml
+++ b/tests/triggers/fixtures/gerrit013-name-and-email-parameter-mode-plain.xml
@@ -9,6 +9,7 @@
         <onFailed>false</onFailed>
         <onUnstable>false</onUnstable>
         <onNotBuilt>false</onNotBuilt>
+        <onAborted>false</onAborted>
       </skipVote>
       <silentMode>false</silentMode>
       <silentStartMode>false</silentStartMode>
@@ -32,6 +33,7 @@
       <buildUnsuccessfulFilepath/>
       <customUrl/>
       <serverName>__ANY__</serverName>
+      <buildAbortedMessage/>
     </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.GerritTrigger>
   </triggers>
 </project>

--- a/tests/triggers/fixtures/gerrit014-commit-message-parameter-mode-base64.xml
+++ b/tests/triggers/fixtures/gerrit014-commit-message-parameter-mode-base64.xml
@@ -9,6 +9,7 @@
         <onFailed>false</onFailed>
         <onUnstable>false</onUnstable>
         <onNotBuilt>false</onNotBuilt>
+        <onAborted>false</onAborted>
       </skipVote>
       <silentMode>false</silentMode>
       <silentStartMode>false</silentStartMode>
@@ -32,6 +33,7 @@
       <buildUnsuccessfulFilepath/>
       <customUrl/>
       <serverName>__ANY__</serverName>
+      <buildAbortedMessage/>
     </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.GerritTrigger>
   </triggers>
 </project>

--- a/tests/triggers/fixtures/gerrit015-commit-message-parameter-mode-plain.xml
+++ b/tests/triggers/fixtures/gerrit015-commit-message-parameter-mode-plain.xml
@@ -9,6 +9,7 @@
         <onFailed>false</onFailed>
         <onUnstable>false</onUnstable>
         <onNotBuilt>false</onNotBuilt>
+        <onAborted>false</onAborted>
       </skipVote>
       <silentMode>false</silentMode>
       <silentStartMode>false</silentStartMode>
@@ -32,6 +33,7 @@
       <buildUnsuccessfulFilepath/>
       <customUrl/>
       <serverName>__ANY__</serverName>
+      <buildAbortedMessage/>
     </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.GerritTrigger>
   </triggers>
 </project>

--- a/tests/triggers/fixtures/gerrit016-commit-message-parameter-mode-none.xml
+++ b/tests/triggers/fixtures/gerrit016-commit-message-parameter-mode-none.xml
@@ -9,6 +9,7 @@
         <onFailed>false</onFailed>
         <onUnstable>false</onUnstable>
         <onNotBuilt>false</onNotBuilt>
+        <onAborted>false</onAborted>
       </skipVote>
       <silentMode>false</silentMode>
       <silentStartMode>false</silentStartMode>
@@ -32,6 +33,7 @@
       <buildUnsuccessfulFilepath/>
       <customUrl/>
       <serverName>__ANY__</serverName>
+      <buildAbortedMessage/>
     </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.GerritTrigger>
   </triggers>
 </project>

--- a/tests/triggers/fixtures/gerrit017-change-subject-parameter-mode-base64.xml
+++ b/tests/triggers/fixtures/gerrit017-change-subject-parameter-mode-base64.xml
@@ -9,6 +9,7 @@
         <onFailed>false</onFailed>
         <onUnstable>false</onUnstable>
         <onNotBuilt>false</onNotBuilt>
+        <onAborted>false</onAborted>
       </skipVote>
       <silentMode>false</silentMode>
       <silentStartMode>false</silentStartMode>
@@ -32,6 +33,7 @@
       <buildUnsuccessfulFilepath/>
       <customUrl/>
       <serverName>__ANY__</serverName>
+      <buildAbortedMessage/>
     </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.GerritTrigger>
   </triggers>
 </project>

--- a/tests/triggers/fixtures/gerrit018-change-subject-parameter-mode-plain.xml
+++ b/tests/triggers/fixtures/gerrit018-change-subject-parameter-mode-plain.xml
@@ -9,6 +9,7 @@
         <onFailed>false</onFailed>
         <onUnstable>false</onUnstable>
         <onNotBuilt>false</onNotBuilt>
+        <onAborted>false</onAborted>
       </skipVote>
       <silentMode>false</silentMode>
       <silentStartMode>false</silentStartMode>
@@ -32,6 +33,7 @@
       <buildUnsuccessfulFilepath/>
       <customUrl/>
       <serverName>__ANY__</serverName>
+      <buildAbortedMessage/>
     </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.GerritTrigger>
   </triggers>
 </project>

--- a/tests/triggers/fixtures/gerrit019-change-subject-parameter-mode-none.xml
+++ b/tests/triggers/fixtures/gerrit019-change-subject-parameter-mode-none.xml
@@ -9,6 +9,7 @@
         <onFailed>false</onFailed>
         <onUnstable>false</onUnstable>
         <onNotBuilt>false</onNotBuilt>
+        <onAborted>false</onAborted>
       </skipVote>
       <silentMode>false</silentMode>
       <silentStartMode>false</silentStartMode>
@@ -32,6 +33,7 @@
       <buildUnsuccessfulFilepath/>
       <customUrl/>
       <serverName>__ANY__</serverName>
+      <buildAbortedMessage/>
     </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.GerritTrigger>
   </triggers>
 </project>

--- a/tests/triggers/fixtures/gerrit020-comment-text-parameter-mode-base64.xml
+++ b/tests/triggers/fixtures/gerrit020-comment-text-parameter-mode-base64.xml
@@ -9,6 +9,7 @@
         <onFailed>false</onFailed>
         <onUnstable>false</onUnstable>
         <onNotBuilt>false</onNotBuilt>
+        <onAborted>false</onAborted>
       </skipVote>
       <silentMode>false</silentMode>
       <silentStartMode>false</silentStartMode>
@@ -32,6 +33,7 @@
       <buildUnsuccessfulFilepath/>
       <customUrl/>
       <serverName>__ANY__</serverName>
+      <buildAbortedMessage/>
     </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.GerritTrigger>
   </triggers>
 </project>

--- a/tests/triggers/fixtures/gerrit021-comment-text-parameter-mode-plain.xml
+++ b/tests/triggers/fixtures/gerrit021-comment-text-parameter-mode-plain.xml
@@ -9,6 +9,7 @@
         <onFailed>false</onFailed>
         <onUnstable>false</onUnstable>
         <onNotBuilt>false</onNotBuilt>
+        <onAborted>false</onAborted>
       </skipVote>
       <silentMode>false</silentMode>
       <silentStartMode>false</silentStartMode>
@@ -32,6 +33,7 @@
       <buildUnsuccessfulFilepath/>
       <customUrl/>
       <serverName>__ANY__</serverName>
+      <buildAbortedMessage/>
     </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.GerritTrigger>
   </triggers>
 </project>

--- a/tests/triggers/fixtures/gerrit022-comment-text-parameter-mode-none.xml
+++ b/tests/triggers/fixtures/gerrit022-comment-text-parameter-mode-none.xml
@@ -9,6 +9,7 @@
         <onFailed>false</onFailed>
         <onUnstable>false</onUnstable>
         <onNotBuilt>false</onNotBuilt>
+        <onAborted>false</onAborted>
       </skipVote>
       <silentMode>false</silentMode>
       <silentStartMode>false</silentStartMode>
@@ -32,6 +33,7 @@
       <buildUnsuccessfulFilepath/>
       <customUrl/>
       <serverName>__ANY__</serverName>
+      <buildAbortedMessage/>
     </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.GerritTrigger>
   </triggers>
 </project>

--- a/tests/triggers/fixtures/gerrit028-trigger-simple-triggers.xml
+++ b/tests/triggers/fixtures/gerrit028-trigger-simple-triggers.xml
@@ -9,6 +9,7 @@
         <onFailed>false</onFailed>
         <onUnstable>false</onUnstable>
         <onNotBuilt>false</onNotBuilt>
+        <onAborted>false</onAborted>
       </skipVote>
       <silentMode>false</silentMode>
       <silentStartMode>false</silentStartMode>
@@ -45,6 +46,7 @@
           <excludeNoCodeChange>true</excludeNoCodeChange>
           <excludePrivateState>false</excludePrivateState>
           <excludeWipState>true</excludeWipState>
+          <commitMessageContainsRegEx>regex</commitMessageContainsRegEx>
         </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginPatchsetCreatedEvent>
         <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginPrivateStateChangedEvent/>
         <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginRefUpdatedEvent/>
@@ -59,6 +61,7 @@
       <buildUnsuccessfulFilepath/>
       <customUrl/>
       <serverName>__ANY__</serverName>
+      <buildAbortedMessage/>
     </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.GerritTrigger>
   </triggers>
 </project>

--- a/tests/triggers/fixtures/gerrit028-trigger-simple-triggers.yaml
+++ b/tests/triggers/fixtures/gerrit028-trigger-simple-triggers.yaml
@@ -19,6 +19,7 @@ triggers:
             exclude-private: false
             exclude-trivial-rebase: false
             exclude-wip: true
+            commit-message-contains-regex: regex
         - private-state-changed-event
         - ref-updated-event
         - topic-changed-event

--- a/tests/triggers/fixtures/gerrit029-skip-vote-2.20.plugins_info.yaml
+++ b/tests/triggers/fixtures/gerrit029-skip-vote-2.20.plugins_info.yaml
@@ -1,0 +1,3 @@
+- longName: 'Gerrit Trigger'
+  shortName: 'gerrit-trigger'
+  version: '2.20.0'

--- a/tests/triggers/fixtures/gerrit029-skip-vote-2.20.xml
+++ b/tests/triggers/fixtures/gerrit029-skip-vote-2.20.xml
@@ -5,18 +5,17 @@
       <spec/>
       <gerritProjects/>
       <skipVote>
-        <onSuccessful>false</onSuccessful>
-        <onFailed>false</onFailed>
-        <onUnstable>false</onUnstable>
-        <onNotBuilt>false</onNotBuilt>
-        <onAborted>false</onAborted>
+        <onSuccessful>true</onSuccessful>
+        <onFailed>true</onFailed>
+        <onUnstable>true</onUnstable>
+        <onNotBuilt>true</onNotBuilt>
       </skipVote>
       <silentMode>false</silentMode>
       <silentStartMode>false</silentStartMode>
       <escapeQuotes>true</escapeQuotes>
       <dependencyJobsNames/>
       <commitMessageParameterMode>BASE64</commitMessageParameterMode>
-      <nameAndEmailParameterMode>NONE</nameAndEmailParameterMode>
+      <nameAndEmailParameterMode>PLAIN</nameAndEmailParameterMode>
       <changeSubjectParameterMode>PLAIN</changeSubjectParameterMode>
       <commentTextParameterMode>BASE64</commentTextParameterMode>
       <notificationLevel/>
@@ -33,7 +32,6 @@
       <buildUnsuccessfulFilepath/>
       <customUrl/>
       <serverName>__ANY__</serverName>
-      <buildAbortedMessage/>
     </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.GerritTrigger>
   </triggers>
 </project>

--- a/tests/triggers/fixtures/gerrit029-skip-vote-2.20.yaml
+++ b/tests/triggers/fixtures/gerrit029-skip-vote-2.20.yaml
@@ -1,0 +1,7 @@
+triggers:
+  - gerrit:
+      skip-vote:
+          successful: true
+          failed: true
+          unstable: true
+          notbuilt: true

--- a/tests/triggers/fixtures/gerrit030-gerrit-vote-value-2.20.plugins_info.yaml
+++ b/tests/triggers/fixtures/gerrit030-gerrit-vote-value-2.20.plugins_info.yaml
@@ -1,0 +1,3 @@
+- longName: 'Gerrit Trigger'
+  shortName: 'gerrit-trigger'
+  version: '2.20.0'

--- a/tests/triggers/fixtures/gerrit030-gerrit-vote-value-2.20.xml
+++ b/tests/triggers/fixtures/gerrit030-gerrit-vote-value-2.20.xml
@@ -9,14 +9,13 @@
         <onFailed>false</onFailed>
         <onUnstable>false</onUnstable>
         <onNotBuilt>false</onNotBuilt>
-        <onAborted>false</onAborted>
       </skipVote>
       <silentMode>false</silentMode>
       <silentStartMode>false</silentStartMode>
       <escapeQuotes>true</escapeQuotes>
       <dependencyJobsNames/>
       <commitMessageParameterMode>BASE64</commitMessageParameterMode>
-      <nameAndEmailParameterMode>NONE</nameAndEmailParameterMode>
+      <nameAndEmailParameterMode>PLAIN</nameAndEmailParameterMode>
       <changeSubjectParameterMode>PLAIN</changeSubjectParameterMode>
       <commentTextParameterMode>BASE64</commentTextParameterMode>
       <notificationLevel/>
@@ -25,6 +24,16 @@
       <dynamicGerritProjects class="empty-list"/>
       <triggerInformationAction/>
       <triggerOnEvents/>
+      <gerritBuildStartedVerifiedValue>0</gerritBuildStartedVerifiedValue>
+      <gerritBuildSuccessfulVerifiedValue>1</gerritBuildSuccessfulVerifiedValue>
+      <gerritBuildFailedVerifiedValue>-1</gerritBuildFailedVerifiedValue>
+      <gerritBuildUnstableVerifiedValue>-1</gerritBuildUnstableVerifiedValue>
+      <gerritBuildNotBuiltVerifiedValue>-1</gerritBuildNotBuiltVerifiedValue>
+      <gerritBuildStartedCodeReviewValue>0</gerritBuildStartedCodeReviewValue>
+      <gerritBuildSuccessfulCodeReviewValue>1</gerritBuildSuccessfulCodeReviewValue>
+      <gerritBuildFailedCodeReviewValue>-1</gerritBuildFailedCodeReviewValue>
+      <gerritBuildUnstableCodeReviewValue>-1</gerritBuildUnstableCodeReviewValue>
+      <gerritBuildNotBuiltCodeReviewValue>-1</gerritBuildNotBuiltCodeReviewValue>
       <buildStartMessage/>
       <buildFailureMessage/>
       <buildSuccessfulMessage/>
@@ -33,7 +42,6 @@
       <buildUnsuccessfulFilepath/>
       <customUrl/>
       <serverName>__ANY__</serverName>
-      <buildAbortedMessage/>
     </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.GerritTrigger>
   </triggers>
 </project>

--- a/tests/triggers/fixtures/gerrit030-gerrit-vote-value-2.20.yaml
+++ b/tests/triggers/fixtures/gerrit030-gerrit-vote-value-2.20.yaml
@@ -1,0 +1,13 @@
+triggers:
+  - gerrit:
+      override-votes: true
+      gerrit-build-started-verified-value: 0
+      gerrit-build-successful-verified-value: 1
+      gerrit-build-failed-verified-value: -1
+      gerrit-build-unstable-verified-value: -1
+      gerrit-build-notbuilt-verified-value: -1
+      gerrit-build-started-codereview-value: 0
+      gerrit-build-successful-codereview-value: 1
+      gerrit-build-failed-codereview-value: -1
+      gerrit-build-unstable-codereview-value: -1
+      gerrit-build-notbuilt-codereview-value: -1

--- a/tests/triggers/fixtures/gerrit031-gerrit-build-cancellation-policy.xml
+++ b/tests/triggers/fixtures/gerrit031-gerrit-build-cancellation-policy.xml
@@ -11,12 +11,18 @@
         <onNotBuilt>false</onNotBuilt>
         <onAborted>false</onAborted>
       </skipVote>
+      <buildCancellationPolicy>
+        <enabled>true</enabled>
+        <abortNewPatchsets>false</abortNewPatchsets>
+        <abortManualPatchsets>true</abortManualPatchsets>
+        <abortSameTopic>true</abortSameTopic>
+      </buildCancellationPolicy>
       <silentMode>false</silentMode>
       <silentStartMode>false</silentStartMode>
       <escapeQuotes>true</escapeQuotes>
       <dependencyJobsNames/>
       <commitMessageParameterMode>BASE64</commitMessageParameterMode>
-      <nameAndEmailParameterMode>NONE</nameAndEmailParameterMode>
+      <nameAndEmailParameterMode>PLAIN</nameAndEmailParameterMode>
       <changeSubjectParameterMode>PLAIN</changeSubjectParameterMode>
       <commentTextParameterMode>BASE64</commentTextParameterMode>
       <notificationLevel/>

--- a/tests/triggers/fixtures/gerrit031-gerrit-build-cancellation-policy.yaml
+++ b/tests/triggers/fixtures/gerrit031-gerrit-build-cancellation-policy.yaml
@@ -1,0 +1,6 @@
+triggers:
+  - gerrit:
+      build-cancellation-policy:
+        abort-new-patchsets: false
+        abort-manual-patchsets: true
+        abort-same-topic: true

--- a/tests/triggers/fixtures/gerrit031-gerrit-messages-2.20.plugins_info.yaml
+++ b/tests/triggers/fixtures/gerrit031-gerrit-messages-2.20.plugins_info.yaml
@@ -1,0 +1,3 @@
+- longName: 'Gerrit Trigger'
+  shortName: 'gerrit-trigger'
+  version: '2.20.0'

--- a/tests/triggers/fixtures/gerrit032-gerrit-messages-2.20.xml
+++ b/tests/triggers/fixtures/gerrit032-gerrit-messages-2.20.xml
@@ -16,7 +16,7 @@
       <escapeQuotes>true</escapeQuotes>
       <dependencyJobsNames/>
       <commitMessageParameterMode>BASE64</commitMessageParameterMode>
-      <nameAndEmailParameterMode>NONE</nameAndEmailParameterMode>
+      <nameAndEmailParameterMode>PLAIN</nameAndEmailParameterMode>
       <changeSubjectParameterMode>PLAIN</changeSubjectParameterMode>
       <commentTextParameterMode>BASE64</commentTextParameterMode>
       <notificationLevel/>
@@ -25,11 +25,11 @@
       <dynamicGerritProjects class="empty-list"/>
       <triggerInformationAction/>
       <triggerOnEvents/>
-      <buildStartMessage/>
-      <buildFailureMessage/>
-      <buildSuccessfulMessage/>
-      <buildUnstableMessage/>
-      <buildNotBuiltMessage/>
+      <buildStartMessage>Start message.</buildStartMessage>
+      <buildFailureMessage>Failed message.</buildFailureMessage>
+      <buildSuccessfulMessage>Success message.</buildSuccessfulMessage>
+      <buildUnstableMessage>Unstable message.</buildUnstableMessage>
+      <buildNotBuiltMessage>Not built message.</buildNotBuiltMessage>
       <buildUnsuccessfulFilepath/>
       <customUrl/>
       <serverName>__ANY__</serverName>

--- a/tests/triggers/fixtures/gerrit032-gerrit-messages-2.20.yaml
+++ b/tests/triggers/fixtures/gerrit032-gerrit-messages-2.20.yaml
@@ -1,0 +1,7 @@
+triggers:
+  - gerrit:
+      start-message: 'Start message.'
+      failure-message: 'Failed message.'
+      successful-message: 'Success message.'
+      unstable-message: 'Unstable message.'
+      notbuilt-message: 'Not built message.'

--- a/tests/triggers/fixtures/gerrit033-gerrit-patchset-created-event-2.20.plugins_info.yaml
+++ b/tests/triggers/fixtures/gerrit033-gerrit-patchset-created-event-2.20.plugins_info.yaml
@@ -1,0 +1,3 @@
+- longName: 'Gerrit Trigger'
+  shortName: 'gerrit-trigger'
+  version: '2.20.0'

--- a/tests/triggers/fixtures/gerrit033-gerrit-patchset-created-event-2.20.xml
+++ b/tests/triggers/fixtures/gerrit033-gerrit-patchset-created-event-2.20.xml
@@ -9,14 +9,13 @@
         <onFailed>false</onFailed>
         <onUnstable>false</onUnstable>
         <onNotBuilt>false</onNotBuilt>
-        <onAborted>false</onAborted>
       </skipVote>
       <silentMode>false</silentMode>
       <silentStartMode>false</silentStartMode>
       <escapeQuotes>true</escapeQuotes>
       <dependencyJobsNames/>
       <commitMessageParameterMode>BASE64</commitMessageParameterMode>
-      <nameAndEmailParameterMode>NONE</nameAndEmailParameterMode>
+      <nameAndEmailParameterMode>PLAIN</nameAndEmailParameterMode>
       <changeSubjectParameterMode>PLAIN</changeSubjectParameterMode>
       <commentTextParameterMode>BASE64</commentTextParameterMode>
       <notificationLevel/>
@@ -24,7 +23,15 @@
       <triggerConfigURL/>
       <dynamicGerritProjects class="empty-list"/>
       <triggerInformationAction/>
-      <triggerOnEvents/>
+      <triggerOnEvents>
+        <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginPatchsetCreatedEvent>
+          <excludeDrafts>true</excludeDrafts>
+          <excludeTrivialRebase>true</excludeTrivialRebase>
+          <excludeNoCodeChange>true</excludeNoCodeChange>
+          <excludePrivateState>true</excludePrivateState>
+          <excludeWipState>true</excludeWipState>
+        </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginPatchsetCreatedEvent>
+      </triggerOnEvents>
       <buildStartMessage/>
       <buildFailureMessage/>
       <buildSuccessfulMessage/>
@@ -33,7 +40,6 @@
       <buildUnsuccessfulFilepath/>
       <customUrl/>
       <serverName>__ANY__</serverName>
-      <buildAbortedMessage/>
     </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.GerritTrigger>
   </triggers>
 </project>

--- a/tests/triggers/fixtures/gerrit033-gerrit-patchset-created-event-2.20.yaml
+++ b/tests/triggers/fixtures/gerrit033-gerrit-patchset-created-event-2.20.yaml
@@ -1,0 +1,9 @@
+triggers:
+  - gerrit:
+      trigger-on:
+          - patchset-created-event:
+              exclude-drafts: true
+              exclude-trivial-rebase: true
+              exclude-no-code-change: true
+              exclude-private: true
+              exclude-wip: true

--- a/tests/yamlparser/fixtures/complete001.xml
+++ b/tests/yamlparser/fixtures/complete001.xml
@@ -65,6 +65,7 @@
         <onFailed>false</onFailed>
         <onUnstable>false</onUnstable>
         <onNotBuilt>false</onNotBuilt>
+        <onAborted>false</onAborted>
       </skipVote>
       <silentMode>false</silentMode>
       <silentStartMode>false</silentStartMode>
@@ -92,6 +93,8 @@
       <gerritBuildFailedCodeReviewValue>-1</gerritBuildFailedCodeReviewValue>
       <gerritBuildUnstableCodeReviewValue>-1</gerritBuildUnstableCodeReviewValue>
       <gerritBuildNotBuiltCodeReviewValue>-1</gerritBuildNotBuiltCodeReviewValue>
+      <gerritBuildAbortedVerifiedValue>0</gerritBuildAbortedVerifiedValue>
+      <gerritBuildAbortedCodeReviewValue>0</gerritBuildAbortedCodeReviewValue>
       <buildStartMessage>Start message.</buildStartMessage>
       <buildFailureMessage>Failed message.</buildFailureMessage>
       <buildSuccessfulMessage>Success message.</buildSuccessfulMessage>
@@ -100,6 +103,7 @@
       <buildUnsuccessfulFilepath/>
       <customUrl/>
       <serverName>__ANY__</serverName>
+      <buildAbortedMessage>Aborted message.</buildAbortedMessage>
     </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.GerritTrigger>
   </triggers>
   <builders>

--- a/tests/yamlparser/fixtures/complete001.yaml
+++ b/tests/yamlparser/fixtures/complete001.yaml
@@ -59,6 +59,8 @@
          gerrit-build-failed-codereview-value: -1
          gerrit-build-unstable-codereview-value: -1
          gerrit-build-notbuilt-codereview-value: -1
+         gerrit-build-aborted-verified-value: 0
+         gerrit-build-aborted-codereview-value: 0
          projects:
            - project-compare-type: 'PLAIN'
              project-pattern: '{project_pattern}'
@@ -70,6 +72,7 @@
          successful-message: 'Success message.'
          unstable-message: 'Unstable message.'
          notbuilt-message: 'Not built message.'
+         aborted-message: 'Aborted message.'
 
 - scm:
     name: gerrit-scm

--- a/tests/yamlparser/fixtures/jinja-yaml01.xml
+++ b/tests/yamlparser/fixtures/jinja-yaml01.xml
@@ -41,6 +41,7 @@
         <onFailed>false</onFailed>
         <onUnstable>false</onUnstable>
         <onNotBuilt>false</onNotBuilt>
+        <onAborted>false</onAborted>
       </skipVote>
       <silentMode>false</silentMode>
       <silentStartMode>false</silentStartMode>
@@ -64,6 +65,7 @@
       <buildUnsuccessfulFilepath/>
       <customUrl/>
       <serverName>__ANY__</serverName>
+      <buildAbortedMessage/>
     </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.GerritTrigger>
   </triggers>
   <builders/>


### PR DESCRIPTION
The changes between plugin version `2.30.0`-`2.32.0` have been
implemented. Current test cases are updated, and also new
test cases are added in order to verify old version XML
output has not been altered.

Documentation uses gerrit004.yaml as an exampple, therefore,
`build-cancellation-policy` have also been implemented to
show as example.

Signed-off-by: Eren Atas <eatas.contractor@libertyglobal.com>