### PR TITLE
Fix 'authorization' property one more time

### DIFF
--- a/jenkins_jobs/modules/properties.py
+++ b/jenkins_jobs/modules/properties.py
@@ -503,7 +503,7 @@ def authenticated_build(registry, xml_parent, data):
     ).text = "hudson.model.Item.Build:authenticated"
 
 
-def authorization(registry, xml_parent, data):
+def authorization(registry, xml_parent, data, job_data):
     """yaml: authorization
     Specifies an authorization matrix
 
@@ -540,8 +540,7 @@ def authorization(registry, xml_parent, data):
        :language: yaml
     """
 
-    # check if it's a folder or a job
-    is_a_folder = data.pop("_is_a_folder", None) if data else False
+    is_a_folder = job_data.get("project-type") in ("folder", "multibranch")
 
     credentials = "com.cloudbees.plugins.credentials.CredentialsProvider."
     ownership = "com.synopsys.arc.jenkins.plugins.ownership.OwnershipPlugin."
@@ -1280,15 +1279,4 @@ class Properties(jenkins_jobs.modules.base.Base):
             properties = XML.SubElement(xml_parent, "properties")
 
         for prop in data.get("properties", []):
-            # Pass a flag for folder permissions to the authorization method
-            if next(iter(prop)) == "authorization":
-                # Only projects are placed in folders
-                if "project-type" in data:
-                    if data["project-type"] in ("folder", "multibranch"):
-                        prop["authorization"]["_is_a_folder"] = True
-                    else:
-                        prop["authorization"]["_is_a_folder"] = False
-                else:
-                    prop["authorization"]["_is_a_folder"] = False
-
-            self.registry.dispatch("property", properties, prop)
+            self.registry.dispatch("property", properties, prop, job_data=data)

--- a/tests/yamlparser/fixtures/project-with-auth-j2-yaml.xml
+++ b/tests/yamlparser/fixtures/project-with-auth-j2-yaml.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<project>
+  <actions/>
+  <description>&lt;!-- Managed by Jenkins Job Builder --&gt;</description>
+  <keepDependencies>false</keepDependencies>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <concurrentBuild>false</concurrentBuild>
+  <canRoam>true</canRoam>
+  <properties>
+    <hudson.security.AuthorizationMatrixProperty>
+      <inheritanceStrategy class="org.jenkinsci.plugins.matrixauth.inheritance.InheritParentStrategy"/>
+      <permission>hudson.model.Item.Build:john</permission>
+      <permission>hudson.model.Item.Cancel:john</permission>
+      <permission>hudson.model.Item.Read:john</permission>
+      <permission>hudson.model.Item.Build:megan</permission>
+      <permission>hudson.model.Item.Cancel:megan</permission>
+      <permission>hudson.model.Item.Read:megan</permission>
+      <permission>hudson.model.Item.Build:steve</permission>
+      <permission>hudson.model.Item.Cancel:steve</permission>
+      <permission>hudson.model.Item.Read:steve</permission>
+    </hudson.security.AuthorizationMatrixProperty>
+  </properties>
+  <scm class="hudson.scm.NullSCM"/>
+  <builders/>
+  <publishers/>
+  <buildWrappers/>
+</project>

--- a/tests/yamlparser/fixtures/project-with-auth-j2-yaml.yaml
+++ b/tests/yamlparser/fixtures/project-with-auth-j2-yaml.yaml
@@ -1,0 +1,14 @@
+- job:
+    name: test
+    authorized_people:
+    - john
+    - megan
+    - steve
+    properties:
+    - authorization: !j2-yaml: |
+        {% for user in authorized_people %}
+        {{ user }}:
+        - job-build
+        - job-cancel
+        - job-read
+        {% endfor %}

--- a/tests/yamlparser/fixtures/project-with-auth-properties.xml
+++ b/tests/yamlparser/fixtures/project-with-auth-properties.xml
@@ -13,10 +13,10 @@
   <concurrentBuild>false</concurrentBuild>
   <canRoam>true</canRoam>
   <properties>
-    <hudson.security.AuthorizationMatrixProperty>
+    <com.cloudbees.hudson.plugins.folder.properties.AuthorizationMatrixProperty>
       <inheritanceStrategy class="org.jenkinsci.plugins.matrixauth.inheritance.InheritParentStrategy"/>
       <permission>hudson.model.Item.Build:auser</permission>
-    </hudson.security.AuthorizationMatrixProperty>
+    </com.cloudbees.hudson.plugins.folder.properties.AuthorizationMatrixProperty>
   </properties>
   <scm class="hudson.scm.NullSCM"/>
   <publishers/>


### PR DESCRIPTION
Due to the fact how dispatching works the 'authorization' property
handler was not always invoked through Properties.gen_xml(), leading to
a bug and an invalid test case: project-with-auth-properties.(yaml/xml)

This change pushes the logic for determining if the object is a
folder/multi-branch project from Properties.gen_xml() to the
authorization() function itself. For that to work the authorization()
function needed access to the top-level job object, which is now
conditionally passed to each dispatched function as a keyword argument,
if the function takes 'job_data' argument. Note that taking this
argument is completely optional so no changes were required in other
handlers. In the future the same approach could be taken to eliminate
the hacks for 'uno-choice' in Parameters.gen_xml().

Additionally ModuleRegistry.dispatch() now merges the top-level job
object with any template data before deep-formatting, so that job-level
properties are now available in Jinja templates. A very nice use case
is in project-with-auth-j2-yaml.yaml test case.

Change-Id: I9a49de74055cd9acfdc87dbad1fc454548643e8f